### PR TITLE
Translate Spanish comments in PHP source

### DIFF
--- a/src/Controller/net/exelearning/Controller/Api/TranslationApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/TranslationApiController.php
@@ -37,7 +37,7 @@ class TranslationApiController extends DefaultApiController
             $translationsDirArray = glob($translationsParentDir.'/*', GLOB_ONLYDIR);
 
             foreach ($translationsDirArray as $path) {
-                // Obtener el locale desde el Request
+                // Get the locale from the Request
                 $locale = $request->getLocale();
 
                 $dataLang = new TranslationListDto();

--- a/src/Service/net/exelearning/Service/Api/PlatformIntegrationService.php
+++ b/src/Service/net/exelearning/Service/Api/PlatformIntegrationService.php
@@ -53,16 +53,16 @@ class PlatformIntegrationService implements PlatformIntegrationServiceInterface
             $fileBase64 = base64_encode($binary);
             $decodedJWT = $this->integrationUtil->decodeJWT($jwtToken);
         } catch (Exception $e) {
-            /* TO DO: mandar mensaje de error */
+            /* TODO: send error message */
             $this->logger->error('Exception:'.$e->getMessage());
-            /* Parar aplicación */
+            /* Stop the application */
         }
 
         $httpClient = HttpClient::create();
 
         $postJson = SettingsUtil::getPlatformJsonStructure();
         $postJson['ode_id'] = $decodedJWT['cmid'];
-        $postJson['ode_filename'] = $odeResultParameters['exportProjectName'] ? $odeResultParameters['exportProjectName'] : $odeResultParameters['elpFileName']; // si viene vacío poner  $odeResultParameters['elpFileName'];
+        $postJson['ode_filename'] = $odeResultParameters['exportProjectName'] ? $odeResultParameters['exportProjectName'] : $odeResultParameters['elpFileName']; // if empty, set  $odeResultParameters['elpFileName'];
         $postJson['ode_file'] = $fileBase64;
         $postJson['ode_user'] = $decodedJWT['userid'];
         $postJson['ode_uri'] = $decodedJWT['returnurl'];

--- a/src/Service/net/exelearning/Service/Export/ExportHTML5SPService.php
+++ b/src/Service/net/exelearning/Service/Export/ExportHTML5SPService.php
@@ -221,7 +221,7 @@ class ExportHTML5SPService implements ExportServiceInterface
         foreach ($domFather->childNodes as $node) {
             if ('section' === $node->nodeName) {
                 continue;
-            } // No mover el nuevo nodo
+            } // Do not move the new node
             if (XML_ELEMENT_NODE === $node->nodeType) {
                 if ($cont < 2) {
                     $nodesToMove[] = $node;

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -108,7 +108,7 @@ class Settings
         'el' => 'Ελληνικά', // Greek
         'en' => 'English',
         'eo' => 'Esperanto',
-        'es' => 'Español', // Español, Spanish
+        'es' => 'Español', // Spanish
         'et' => 'Eesti', // Estonian
         'eu' => 'Euskara', // Basque
         'fa' => 'فارسی', // Farsi, Persian
@@ -135,7 +135,7 @@ class Settings
         'ru' => 'Русский', // Russian
         'sk' => 'Slovenčina, slovenský jazyk', // Jazyk - Slovak
         'sl' => 'Slovenščina', // Slovene
-        'sr' => 'Српски / srpski', // Srpski, serbio
+        'sr' => 'Српски / srpski', // Srpski, Serbian
         'sv' => 'Svenska', // Swedish
         'th' => 'ไทย', // Thai
         'tl' => 'Wikang Tagalog, ᜏᜒᜃᜅ᜔ ᜆᜄᜎᜓᜄ᜔', // Tagalog

--- a/src/Util/net/exelearning/Util/ExportXmlUtil.php
+++ b/src/Util/net/exelearning/Util/ExportXmlUtil.php
@@ -526,7 +526,7 @@ class ExportXmlUtil
         $resource->addAttribute('type', 'webcontent');
         if (in_array($exportType, [Constants::EXPORT_TYPE_SCORM12, Constants::EXPORT_TYPE_SCORM2004])) {
             // The next code is an example of how to add a namespace to the attribute
-            // $adlcp_ns = 'http://www.adlnet.org/xsd/adlcp_rootv1p2'; // Ejemplo de URI de namespace
+            // $adlcp_ns = 'http://www.adlnet.org/xsd/adlcp_rootv1p2'; // Example of namespace URI
             // $resource->addAttribute('scormtype', 'sco', $adlcp_ns);
             $resource->addAttribute('adlcp:adlcp:scormtype', 'asset');
         }

--- a/src/Util/net/exelearning/Util/OdeOldXmlIdevices/OdeOldXmlImageMagnifierIdevice.php
+++ b/src/Util/net/exelearning/Util/OdeOldXmlIdevices/OdeOldXmlImageMagnifierIdevice.php
@@ -135,7 +135,7 @@ class OdeOldXmlImageMagnifierIdevice
                 $lupaGlobals[$key] = isset($node[0]) ? (string) $node[0]['value'] : '';
             }
 
-            // Extraer el valor de 'float' del XML
+            // Extract the value of 'float' from the XML
             $floatValue = '';
             $floatNodes = $galleryImageNode->xpath(
                 "f:dictionary/f:string[@value='float']/following-sibling::f:unicode[1]"


### PR DESCRIPTION
## Summary
- translate Spanish comments across controllers, services, and utilities into English
- clarify locale and namespace handling in translation and export services
- refine application shutdown comment in platform integration

## Testing
- `composer php-cs-checker`
- `composer phpunit` *(fails: SQLSTATE[HY000] [14] unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68a47bb4444c8322a12a45f572808dda