### PR TITLE
Security audit: fix 32 confirmed vulnerabilities (10 critical / 16 high / 5 medium / 1 low)

### DIFF
--- a/public/app/utils/sanitizeHtml.js
+++ b/public/app/utils/sanitizeHtml.js
@@ -1,0 +1,101 @@
+/**
+ * HTML Sanitization Utilities - XSS protection for untrusted HTML
+ *
+ * Used to neutralize active content (scripts, inline event handlers,
+ * javascript: URLs) in HTML that originates from an untrusted source —
+ * notably iDevice content pushed by a REMOTE collaborator over Yjs.
+ *
+ * A malicious collaborator could otherwise inject payloads such as
+ * `<img src=x onerror=...>` that would execute, zero-click, in every other
+ * collaborator's authenticated session when the remote update is rendered.
+ *
+ * Strategy:
+ * - Primary: DOMPurify (vendored at /libs/dompurify/purify.min.js, exposed
+ *   as the global `window.DOMPurify`). DOMPurify's defaults already strip
+ *   <script>, on* handler attributes and javascript: URLs while keeping
+ *   benign structural markup. We extend the allow-list so that legitimate
+ *   educational media (iframes/embeds) keeps rendering.
+ * - Fail-safe fallback: if DOMPurify is unavailable for any reason, do NOT
+ *   return the raw string. Apply a conservative regex-based scrub that
+ *   removes <script> blocks, on* handler attributes and javascript: URLs.
+ *   This is intentionally aggressive (it may over-strip) because failing
+ *   open would re-introduce the vulnerability.
+ */
+
+/**
+ * DOMPurify configuration for collaborative iDevice content.
+ *
+ * Educational iDevices legitimately embed media (YouTube, H5P, maps, ...)
+ * via <iframe>, so iframes and their common embedding attributes are
+ * explicitly allowed. Everything dangerous (scripts, on* handlers,
+ * javascript:/data:script URLs) is still stripped by DOMPurify defaults.
+ *
+ * Note: interactive iDevice behavior is re-attached afterwards by
+ * loadInitScriptIdevice('export') from the iDevice's own JS modules, so
+ * stripping inline scripts/handlers here does NOT remove legitimate
+ * interactivity.
+ */
+export const COLLABORATIVE_HTML_CONFIG = {
+    ADD_TAGS: ['iframe'],
+    ADD_ATTR: ['target', 'allow', 'allowfullscreen', 'frameborder', 'scrolling'],
+};
+
+let fallbackWarningShown = false;
+
+/**
+ * Conservative regex-based scrub used only when DOMPurify is unavailable.
+ * Removes <script> blocks, inline on* handler attributes and javascript:
+ * URLs. Aggressive by design — failing safe is preferred over failing open.
+ *
+ * @param {string} html
+ * @returns {string}
+ */
+function fallbackSanitize(html) {
+    if (!fallbackWarningShown && typeof console !== 'undefined' && typeof console.warn === 'function') {
+        fallbackWarningShown = true;
+        console.warn(
+            '[sanitizeHtml] DOMPurify is not available; using conservative fallback ' +
+                'sanitizer for collaborative HTML. Active content will be stripped.',
+        );
+    }
+
+    return (
+        html
+            // Drop entire <script>...</script> blocks (including unclosed ones).
+            .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, '')
+            .replace(/<script\b[^>]*>/gi, '')
+            // Drop inline event-handler attributes: on*="..." / on*='...' / on*=value
+            .replace(/\son[a-z0-9_-]+\s*=\s*"[^"]*"/gi, '')
+            .replace(/\son[a-z0-9_-]+\s*=\s*'[^']*'/gi, '')
+            .replace(/\son[a-z0-9_-]+\s*=\s*[^\s>]+/gi, '')
+            // Neutralize javascript: URLs (e.g. href/src) by blanking the scheme.
+            .replace(/javascript\s*:/gi, '')
+    );
+}
+
+/**
+ * Sanitize HTML coming from an untrusted collaborator before injecting it
+ * into the DOM via innerHTML.
+ *
+ * @param {string} html - Raw HTML (typically componentData.htmlContent).
+ * @returns {string} Sanitized HTML safe for innerHTML assignment.
+ */
+export function sanitizeCollaborativeHtml(html) {
+    if (html === null || html === undefined) return '';
+
+    const input = typeof html === 'string' ? html : String(html);
+
+    if (typeof window !== 'undefined' && window.DOMPurify && typeof window.DOMPurify.sanitize === 'function') {
+        return window.DOMPurify.sanitize(input, COLLABORATIVE_HTML_CONFIG);
+    }
+
+    return fallbackSanitize(input);
+}
+
+// Also expose globally for non-ES-module consumers (mirrors AvatarUtils).
+if (typeof window !== 'undefined') {
+    window.SanitizeHtml = {
+        sanitizeCollaborativeHtml,
+        COLLABORATIVE_HTML_CONFIG,
+    };
+}

--- a/public/app/utils/sanitizeHtml.test.js
+++ b/public/app/utils/sanitizeHtml.test.js
@@ -1,0 +1,139 @@
+/**
+ * sanitizeHtml Tests
+ *
+ * Unit tests for the collaborative HTML sanitizer used to prevent stored
+ * DOM-XSS when rendering iDevice content received from a remote collaborator
+ * over Yjs.
+ *
+ * Run with: make test-frontend
+ */
+
+import { COLLABORATIVE_HTML_CONFIG, sanitizeCollaborativeHtml } from './sanitizeHtml.js';
+
+// Load the real vendored DOMPurify (UMD) so the primary path is exercised
+// exactly as in production. The UMD wrapper attaches to globalThis.DOMPurify.
+import createDOMPurify from '../../libs/dompurify/purify.min.js';
+
+describe('sanitizeHtml', () => {
+    describe('with real DOMPurify (primary path)', () => {
+        beforeEach(() => {
+            // The vendored UMD build either returns a factory or an instance.
+            const dp = typeof createDOMPurify === 'function' ? createDOMPurify(window) : createDOMPurify;
+            window.DOMPurify = dp;
+        });
+
+        afterEach(() => {
+            delete window.DOMPurify;
+        });
+
+        it('exposes DOMPurify for the test (sanity check)', () => {
+            expect(window.DOMPurify).toBeTruthy();
+            expect(typeof window.DOMPurify.sanitize).toBe('function');
+        });
+
+        it('neutralizes <img onerror=...> XSS payloads', () => {
+            const out = sanitizeCollaborativeHtml('<img src=x onerror="window.__xss=1">');
+            expect(out).not.toMatch(/onerror/i);
+            expect(out).not.toMatch(/__xss/);
+            // The benign <img> element itself is preserved.
+            expect(out).toMatch(/<img/i);
+        });
+
+        it('removes <script> tags entirely', () => {
+            const out = sanitizeCollaborativeHtml('<p>hi</p><script>window.__xss=1</script>');
+            expect(out).not.toMatch(/<script/i);
+            expect(out).not.toMatch(/__xss/);
+            expect(out).toMatch(/<p>hi<\/p>/);
+        });
+
+        it('strips javascript: URLs', () => {
+            const out = sanitizeCollaborativeHtml('<a href="javascript:window.__xss=1">x</a>');
+            expect(out.toLowerCase()).not.toContain('javascript:');
+        });
+
+        it('preserves benign structural markup', () => {
+            const out = sanitizeCollaborativeHtml('<p><strong>ok</strong></p>');
+            expect(out).toBe('<p><strong>ok</strong></p>');
+        });
+
+        it('preserves educational iframe embeds and embed attributes', () => {
+            const html =
+                '<iframe src="https://www.youtube.com/embed/abc" allow="fullscreen" ' +
+                'allowfullscreen frameborder="0"></iframe>';
+            const out = sanitizeCollaborativeHtml(html);
+            expect(out).toMatch(/<iframe/i);
+            expect(out).toMatch(/src="https:\/\/www\.youtube\.com\/embed\/abc"/);
+            expect(out).toMatch(/allowfullscreen/);
+            expect(out).toMatch(/frameborder="0"/);
+        });
+
+        it('returns empty string for null/undefined', () => {
+            expect(sanitizeCollaborativeHtml(null)).toBe('');
+            expect(sanitizeCollaborativeHtml(undefined)).toBe('');
+        });
+
+        it('exports a config that allows iframes and embed attributes', () => {
+            expect(COLLABORATIVE_HTML_CONFIG.ADD_TAGS).toContain('iframe');
+            expect(COLLABORATIVE_HTML_CONFIG.ADD_ATTR).toEqual(
+                expect.arrayContaining(['allow', 'allowfullscreen', 'frameborder', 'scrolling', 'target']),
+            );
+        });
+    });
+
+    describe('fallback path (DOMPurify unavailable)', () => {
+        let warnSpy;
+
+        beforeEach(() => {
+            delete window.DOMPurify;
+            warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            warnSpy.mockRestore();
+            vi.resetModules();
+        });
+
+        it('still neutralizes onerror handlers without DOMPurify', async () => {
+            // Fresh module instance so the one-time warning fires.
+            const mod = await import('./sanitizeHtml.js?fallback-1');
+            const out = mod.sanitizeCollaborativeHtml('<img src=x onerror="window.__xss=1">');
+            expect(out).not.toMatch(/onerror/i);
+            expect(out).not.toMatch(/__xss/);
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('removes <script> blocks in the fallback', async () => {
+            const mod = await import('./sanitizeHtml.js?fallback-2');
+            const out = mod.sanitizeCollaborativeHtml('<p>hi</p><script>window.__xss=1</script>');
+            expect(out).not.toMatch(/<script/i);
+            expect(out).not.toMatch(/__xss/);
+            expect(out).toContain('<p>hi</p>');
+        });
+
+        it('strips javascript: URLs in the fallback', async () => {
+            const mod = await import('./sanitizeHtml.js?fallback-3');
+            const out = mod.sanitizeCollaborativeHtml('<a href="javascript:alert(1)">x</a>');
+            expect(out.toLowerCase()).not.toContain('javascript:');
+        });
+
+        it('does not return the raw dangerous string (fail safe, not open)', async () => {
+            const mod = await import('./sanitizeHtml.js?fallback-4');
+            const raw = '<img src=x onerror="steal()">';
+            const out = mod.sanitizeCollaborativeHtml(raw);
+            expect(out).not.toBe(raw);
+        });
+
+        it('returns empty string for null/undefined in the fallback', async () => {
+            const mod = await import('./sanitizeHtml.js?fallback-5');
+            expect(mod.sanitizeCollaborativeHtml(null)).toBe('');
+            expect(mod.sanitizeCollaborativeHtml(undefined)).toBe('');
+        });
+
+        it('only warns once per module instance', async () => {
+            const mod = await import('./sanitizeHtml.js?fallback-6');
+            mod.sanitizeCollaborativeHtml('<b>a</b>');
+            mod.sanitizeCollaborativeHtml('<b>b</b>');
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/public/app/workarea/modals/modals/pages/modalFileManager.js
+++ b/public/app/workarea/modals/modals/pages/modalFileManager.js
@@ -1396,7 +1396,7 @@ export default class ModalFilemanager extends Modal {
         if (this.showRefCount) {
             const usageCount = this.getAssetUsageCount(asset.id);
             const badgeClass = usageCount > 0 ? 'bg-primary' : 'bg-danger';
-            nameCell.innerHTML = `<span class="filename">${asset.filename || _('Unknown')}</span> <span class="badge rounded-pill ${badgeClass} badge-sm">${usageCount}</span>`;
+            nameCell.innerHTML = `<span class="filename">${this.escapeHtml(asset.filename || _('Unknown'))}</span> <span class="badge rounded-pill ${badgeClass} badge-sm">${usageCount}</span>`;
         } else {
             nameCell.textContent = asset.filename || _('Unknown');
         }

--- a/public/app/workarea/modals/modals/pages/modalFileManager.test.js
+++ b/public/app/workarea/modals/modals/pages/modalFileManager.test.js
@@ -492,6 +492,64 @@ it('should filter by accept=3d for 3D models', () => {
     });
   });
 
+  describe('createListRow - XSS in reference-count branch (H12)', () => {
+    beforeEach(() => {
+      // Enable the reference-count badge branch and force a deterministic
+      // usage count so getAssetUsageCount() does not depend on the document.
+      modal.showRefCount = true;
+      modal.assetUsageCounts = new Map();
+    });
+
+    it('escapes a malicious filename instead of executing it as HTML', () => {
+      modal.assetUsageCounts.set('evil', 3);
+      const asset = {
+        id: 'evil',
+        filename: '<img src=x onerror="window.__xss=1">.png',
+        mime: 'image/png',
+        blob: new Blob(['x']),
+      };
+
+      window.__xss = undefined;
+      const row = modal.createListRow(asset);
+      const nameCell = row.querySelector('.col-name');
+
+      // No live <img> element must be created from the untrusted filename.
+      expect(nameCell.querySelector('img')).toBeNull();
+      // The onerror payload never executes.
+      expect(window.__xss).toBeUndefined();
+      // The filename is rendered verbatim as text inside the filename span.
+      const filenameSpan = nameCell.querySelector('.filename');
+      expect(filenameSpan).not.toBeNull();
+      expect(filenameSpan.textContent).toBe('<img src=x onerror="window.__xss=1">.png');
+      // The static badge still renders the usage count.
+      const badge = nameCell.querySelector('.badge');
+      expect(badge).not.toBeNull();
+      expect(badge.textContent).toBe('3');
+      expect(badge.classList.contains('bg-primary')).toBe(true);
+    });
+
+    it('renders a benign filename unchanged in the reference-count branch', () => {
+      modal.assetUsageCounts.set('ok', 0);
+      const asset = {
+        id: 'ok',
+        filename: 'photo.png',
+        mime: 'image/png',
+        blob: new Blob(['x']),
+      };
+
+      const row = modal.createListRow(asset);
+      const nameCell = row.querySelector('.col-name');
+      const filenameSpan = nameCell.querySelector('.filename');
+
+      expect(filenameSpan).not.toBeNull();
+      expect(filenameSpan.textContent).toBe('photo.png');
+      const badge = nameCell.querySelector('.badge');
+      expect(badge.textContent).toBe('0');
+      // Zero references => danger badge variant.
+      expect(badge.classList.contains('bg-danger')).toBe(true);
+    });
+  });
+
   describe('showSearchIndicator', () => {
     it('should show location column header when entering search mode', () => {
       // Setup: add location column header to mock DOM

--- a/public/app/workarea/project/idevices/idevicesEngine.js
+++ b/public/app/workarea/project/idevices/idevicesEngine.js
@@ -6,6 +6,7 @@
 import IdeviceNode from './content/ideviceNode.js';
 import IdeviceBlockNode from './content/blockNode.js';
 import { getInitials, generateGravatarUrl } from '../../../utils/avatarUtils.js';
+import { sanitizeCollaborativeHtml } from '../../../utils/sanitizeHtml.js';
 
 // Use global AppLogger for debug-controlled logging
 const Logger = window.AppLogger || console;
@@ -1534,7 +1535,11 @@ export default class IdevicesEngine {
             // This preserves existing behavior and unit-test expectations while
             // loadInitScriptIdevice('export') performs full iDevice re-render.
             if (componentData.htmlContent !== undefined) {
-                ideviceNode.ideviceBody.innerHTML = componentData.htmlContent || '';
+                // SECURITY: this HTML originates from a REMOTE collaborator over
+                // Yjs and is attacker-controlled. Sanitize before injecting via
+                // innerHTML to prevent stored DOM-XSS. Legitimate interactivity
+                // is re-attached below by loadInitScriptIdevice('export').
+                ideviceNode.ideviceBody.innerHTML = sanitizeCollaborativeHtml(componentData.htmlContent);
             }
             await ideviceNode.loadInitScriptIdevice('export');
         }

--- a/public/app/yjs/AssetManager.js
+++ b/public/app/yjs/AssetManager.js
@@ -234,9 +234,33 @@ class AssetManager {
       await cache.put(this._getCacheRequestUrl(id), response);
     } catch (e) {
       console.warn('[AssetManager] Cache API write failed:', e.message);
-      if (/unsupported|scheme|Failed to execute/i.test(e.message || '')) {
-        this._disableCachePersistence(e);
-        await this._putToIdb(id, blob);
+
+      const isQuotaExceeded = !!e && (e.name === 'QuotaExceededError' || /quota/i.test(e.message || ''));
+      if (isQuotaExceeded) {
+        // Browser Cache API storage is full. Surface a clear operator signal;
+        // the IDB fallback below takes over as the persistence layer.
+        console.warn('[AssetManager] Cache API storage full (QuotaExceededError) — falling back to IndexedDB:', id);
+      }
+
+      // For ANY Cache write failure (unsupported scheme, quota exceeded,
+      // transient, or unknown), the blob is NOT yet persisted. The Cache API has
+      // proven unreliable for this write, so disable it and route persistence to
+      // IndexedDB. Disabling also makes _getFromCache read from IDB, keeping the
+      // write and read paths consistent — otherwise the IDB-persisted blob would
+      // be unreadable (still effectively lost).
+      this._disableCachePersistence(e);
+
+      // Fall back to IndexedDB and verify a persistent copy actually landed
+      // there. _putToCache must never resolve as success without a confirmed
+      // persistent write — otherwise its callers (putAsset/putBlob) evict the
+      // only in-memory copy in their .then(), destroying the blob in every store
+      // at once (#H7).
+      await this._putToIdb(id, blob);
+      const persisted = await this._getFromIdb(id);
+      if (!persisted) {
+        // Neither Cache API nor IndexedDB hold the blob. Re-throw so the
+        // caller's .catch() keeps the blob in memory instead of evicting it.
+        throw e;
       }
     }
   }

--- a/public/app/yjs/AssetManager.test.js
+++ b/public/app/yjs/AssetManager.test.js
@@ -64,10 +64,12 @@ describe('AssetManager', () => {
     // Create mock IndexedDB store (now only stores blobs)
     const storedBlobs = new Map();
 
-    // The mock below is vestigial — AssetManager uses in-memory + Cache API now.
-    // Requests must still fire onsuccess asynchronously so the IndexedDB fallback
-    // introduced in #1710 resolves cleanly when tests simulate a missing Cache API
-    // (via `delete global.caches`). Without `queueMicrotask`, fallback awaits hang.
+    // Functional in-memory IndexedDB stand-in for the #1710 fallback. The real
+    // _putToIdb stores records keyed by the compound `key` (`${projectId}:${assetId}`)
+    // and _getFromIdb reads them back by that same key, so the mock keys on
+    // `blobRecord.key` (not `.id`) to faithfully support the fallback path the
+    // Cache API error handling now relies on (#H7). Requests still fire
+    // onsuccess asynchronously so awaits resolve cleanly.
     const fireRequestAsync = (request) => {
       queueMicrotask(() => {
         if (request.onsuccess) request.onsuccess({ target: request });
@@ -76,15 +78,15 @@ describe('AssetManager', () => {
     };
     mockStore = {
       put: mock((blobRecord) => {
-        storedBlobs.set(blobRecord.id, blobRecord);
+        storedBlobs.set(blobRecord.key, blobRecord);
         return fireRequestAsync({ result: undefined, error: null, onsuccess: null, onerror: null });
       }),
-      get: mock((id) => {
-        const result = storedBlobs.get(id) || null;
+      get: mock((key) => {
+        const result = storedBlobs.get(key) || null;
         return fireRequestAsync({ result, error: null, onsuccess: null, onerror: null });
       }),
-      delete: mock((id) => {
-        storedBlobs.delete(id);
+      delete: mock((key) => {
+        storedBlobs.delete(key);
         return fireRequestAsync({ result: undefined, error: null, onsuccess: null, onerror: null });
       }),
       index: mock(() => ({
@@ -8636,6 +8638,7 @@ describe('AssetManager - getAssetForUpload (line 4090)', () => {
 describe('AssetManager - storeAssetFromServer paths (lines 4134-4164)', () => {
   let assetManager;
   let mockYjsBridge;
+  let savedWindow;
 
   beforeEach(() => {
     global.Logger = { log: vi.fn() };
@@ -8644,7 +8647,26 @@ describe('AssetManager - storeAssetFromServer paths (lines 4134-4164)', () => {
       value: { randomUUID: vi.fn(() => 'uuid'), subtle: { digest: vi.fn(async () => new Uint8Array(32).buffer) } },
       writable: true, configurable: true,
     });
-    global.caches = { open: vi.fn(), delete: vi.fn() };
+    // Earlier tests may have run `delete global.window`; _getCacheRequestUrl()
+    // reads window.location.protocol, so ensure a window object is present.
+    savedWindow = global.window;
+    global.window = { location: { protocol: 'https:' } };
+    // Functional Cache API so _putToCache resolves via a real persistent write
+    // (storeAssetFromServer awaits _putToCache, which after #H7 must not resolve
+    // unless a persistent copy actually exists).
+    const cacheStorage = new Map();
+    global.caches = {
+      open: vi.fn(async (name) => {
+        if (!cacheStorage.has(name)) cacheStorage.set(name, new Map());
+        const cache = cacheStorage.get(name);
+        return {
+          put: async (url, response) => { cache.set(url, response); },
+          match: async (url) => cache.get(url),
+          delete: async (url) => cache.delete(url),
+        };
+      }),
+      delete: vi.fn(async (name) => cacheStorage.delete(name)),
+    };
     spyOn(console, 'warn').mockImplementation(() => {});
 
     mockYjsBridge = (() => {
@@ -8667,6 +8689,11 @@ describe('AssetManager - storeAssetFromServer paths (lines 4134-4164)', () => {
     delete global.Logger;
     delete global.URL;
     delete global.caches;
+    if (savedWindow === undefined) {
+      delete global.window;
+    } else {
+      global.window = savedWindow;
+    }
   });
 
   it('stores blob for existing asset without blob (lines 4119-4143)', async () => {
@@ -14512,6 +14539,7 @@ describe('AssetManager IndexedDB fallback when Cache API is unavailable', () => 
   let originalIDBKeyRange;
   let originalCaches;
   let originalLogger;
+  let originalWindow;
   let fakeIdb;
 
   /**
@@ -14688,6 +14716,31 @@ describe('AssetManager IndexedDB fallback when Cache API is unavailable', () => 
     };
   };
 
+  // Cache API that opens fine but rejects writes with a real QuotaExceededError
+  // (message "Quota exceeded.", name "QuotaExceededError"). This is the exact
+  // shape the browser throws when storage is full — it matches NONE of the
+  // scheme/unsupported patterns, so before #H7 _putToCache swallowed it and
+  // resolved as success, letting putAsset/putBlob evict the only in-memory copy.
+  const installQuotaExceededCacheApi = () => {
+    global.caches = {
+      open: mock(async () => ({
+        put: mock(async () => {
+          throw Object.assign(new Error('Quota exceeded.'), { name: 'QuotaExceededError' });
+        }),
+        match: mock(async () => undefined),
+        delete: mock(async () => false),
+      })),
+      delete: mock(async () => true),
+    };
+  };
+
+  // Remove IndexedDB entirely so the Cache→IDB fallback has nowhere to land.
+  // Used to prove that when NO persistent store accepts the blob, _putToCache
+  // rejects (and callers keep the blob in memory) instead of silently losing it.
+  const disableIndexedDb = () => {
+    global.indexedDB = undefined;
+  };
+
   const installWorkingCacheApi = () => {
     const storage = new Map();
     global.caches = {
@@ -14710,6 +14763,11 @@ describe('AssetManager IndexedDB fallback when Cache API is unavailable', () => 
     originalIDBKeyRange = global.IDBKeyRange;
     originalCaches = global.caches;
     originalLogger = global.Logger;
+    // Earlier tests in this file run `delete global.window`, and happy-dom does
+    // not recreate `window` per test. _getCacheRequestUrl() reads
+    // window.location.protocol, so guarantee a window object exists here.
+    originalWindow = global.window;
+    global.window = { location: { protocol: 'https:' } };
     global.Logger = { log: () => {} };
     fakeIdb = installFakeIndexedDB();
     spyOn(console, 'log').mockImplementation(() => {});
@@ -14722,6 +14780,11 @@ describe('AssetManager IndexedDB fallback when Cache API is unavailable', () => 
     global.IDBKeyRange = originalIDBKeyRange;
     global.caches = originalCaches;
     global.Logger = originalLogger;
+    if (originalWindow === undefined) {
+      delete global.window;
+    } else {
+      global.window = originalWindow;
+    }
     fakeIdb = null;
   });
 
@@ -14801,5 +14864,96 @@ describe('AssetManager IndexedDB fallback when Cache API is unavailable', () => 
     expect(global.caches.open).toHaveBeenCalledWith('exe-assets-project-secure');
     expect(mgr.cachePersistenceDisabled).toBe(false);
     expect(fakeIdb.entriesForProject('project-secure')).toEqual([]);
+  });
+
+  // =========================================================================
+  // QuotaExceededError handling — bug #H7
+  // =========================================================================
+  // When the Cache API rejects a write with QuotaExceededError (storage full),
+  // its message ("Quota exceeded.") and name ("QuotaExceededError") match none
+  // of the scheme/unsupported patterns the old catch checked. The old code
+  // therefore swallowed the error and let _putToCache resolve as success, so
+  // putAsset/putBlob evicted the only in-memory copy in their .then() — leaving
+  // the blob in no store at all (lost on save and on reload). The fix routes
+  // ANY Cache write failure through IndexedDB and only resolves once a
+  // persistent copy exists; otherwise it rejects so callers keep memory.
+  describe('QuotaExceededError on Cache API write (#H7)', () => {
+    it('falls back to IndexedDB when cache.put throws QuotaExceededError', async () => {
+      installQuotaExceededCacheApi();
+      const mgr = new AssetManager('project-quota');
+
+      const blob = new Blob(['quota-fallback'], { type: 'image/png' });
+      // Must resolve (a persistent copy exists in IDB) — not reject, not lose data.
+      await mgr._putToCache('asset-quota', blob);
+
+      // Blob was routed to IndexedDB instead of being silently dropped.
+      const idbEntries = fakeIdb.entriesForProject('project-quota');
+      expect(idbEntries.length).toBe(1);
+      expect(idbEntries[0].blob).toBeInstanceOf(Blob);
+
+      // And it is retrievable again (the real failure mode: getBlob returning null).
+      const retrieved = await mgr.getBlob('asset-quota');
+      expect(retrieved).toBeInstanceOf(Blob);
+      expect(await retrieved.text()).toBe('quota-fallback');
+    });
+
+    it('putAsset keeps the blob retrievable after a QuotaExceededError (no total loss)', async () => {
+      installQuotaExceededCacheApi();
+      const mgr = new AssetManager('project-quota-asset');
+      mgr.setYjsBridge(createMockYjsBridge());
+
+      const blob = new Blob(['must-survive-quota'], { type: 'image/png' });
+      await mgr.putAsset({
+        id: 'asset-pa',
+        filename: 'pic.png',
+        folderPath: '',
+        mime: 'image/png',
+        size: blob.size,
+        hash: 'h-pa',
+        blob,
+      });
+
+      // putAsset fires _putToCache asynchronously, then evicts memory on success.
+      // Eviction is legitimate here ONLY because the blob landed in IndexedDB.
+      await new Promise((r) => setTimeout(r, 50));
+
+      // The blob must still be retrievable — from memory or from the IDB fallback.
+      const retrieved = await mgr.getBlob('asset-pa');
+      expect(retrieved).toBeInstanceOf(Blob);
+      expect(await retrieved.text()).toBe('must-survive-quota');
+
+      // Confirm it actually persisted (not merely lingering in memory).
+      expect(fakeIdb.entriesForProject('project-quota-asset').length).toBe(1);
+    });
+
+    it('rejects (and caller keeps memory) when BOTH Cache API and IndexedDB fail', async () => {
+      installQuotaExceededCacheApi();
+      disableIndexedDb();
+      const mgr = new AssetManager('project-no-store');
+
+      const blob = new Blob(['nowhere-to-persist'], { type: 'image/png' });
+
+      // No persistent store accepted the blob → _putToCache must reject so the
+      // caller's .catch() can retain the in-memory copy.
+      await expect(mgr._putToCache('asset-orphan', blob)).rejects.toThrow();
+    });
+
+    it('putBlob retains the blob in memory when neither Cache API nor IndexedDB persist', async () => {
+      installQuotaExceededCacheApi();
+      disableIndexedDb();
+      const mgr = new AssetManager('project-keep-mem');
+
+      const blob = new Blob(['keep-me-in-ram'], { type: 'image/png' });
+      await mgr.putBlob('asset-keep', blob);
+
+      // Wait for the async _putToCache().catch() path to settle.
+      await new Promise((r) => setTimeout(r, 50));
+
+      // _putToCache rejected → the blob must NOT have been evicted from memory.
+      expect(mgr.blobCache.has('asset-keep')).toBe(true);
+      const retrieved = await mgr.getBlob('asset-keep');
+      expect(retrieved).toBeInstanceOf(Blob);
+      expect(await retrieved.text()).toBe('keep-me-in-ram');
+    });
   });
 });

--- a/src/db/queries/projects.spec.ts
+++ b/src/db/queries/projects.spec.ts
@@ -513,6 +513,84 @@ describe('Project Queries', () => {
             expect(collaborators.some(c => c.id === testUser.id)).toBe(true);
             expect(collaborators.some(c => c.id === otherCollab.id)).toBe(true);
         });
+
+        it('should roll back all writes atomically when a mid-sequence step fails', async () => {
+            const newOwner = await createUser(db, {
+                email: 'rollback-owner@example.com',
+                user_id: 'rollback-owner',
+                password: 'h',
+            });
+
+            const project = await createProject(db, {
+                title: 'Rollback Test',
+                owner_id: testUser.id,
+            });
+
+            // New owner must be a collaborator so the pre-checks pass and the
+            // function proceeds to the write phase (removeCollaborator ->
+            // addCollaborator -> UPDATE owner_id).
+            await addCollaborator(db, project.id, newOwner.id);
+
+            // Wrap db so the transaction callback runs against a trx proxy whose
+            // final `updateTable('projects')` step throws. This simulates a
+            // mid-sequence failure AFTER the collaborator writes have executed
+            // inside the transaction, exercising a real SQLite rollback.
+            // Kysely methods access private fields (this.#props), so any
+            // delegated method MUST be bound back to its real target — otherwise
+            // `this` becomes the proxy and private-field access throws.
+            const bindToTarget = <O extends object>(target: O, prop: string | symbol, receiver: unknown): unknown => {
+                const value = Reflect.get(target, prop, receiver);
+                return typeof value === 'function' ? value.bind(target) : value;
+            };
+
+            const failingDb = new Proxy(db, {
+                get(target, prop, receiver) {
+                    if (prop === 'transaction') {
+                        return () => {
+                            const builder = target.transaction();
+                            return {
+                                execute<T>(cb: (trx: typeof db) => Promise<T>): Promise<T> {
+                                    return builder.execute(realTrx => {
+                                        const trxProxy = new Proxy(realTrx, {
+                                            get(trxTarget, trxProp, trxReceiver) {
+                                                if (trxProp === 'updateTable') {
+                                                    return () => {
+                                                        throw new Error('Injected write failure');
+                                                    };
+                                                }
+                                                return bindToTarget(trxTarget, trxProp, trxReceiver);
+                                            },
+                                        });
+                                        return cb(trxProxy as typeof db);
+                                    });
+                                },
+                            };
+                        };
+                    }
+                    return bindToTarget(target, prop, receiver);
+                },
+            });
+
+            await expect(transferOwnership(failingDb, project.id, newOwner.id)).rejects.toThrow(
+                'Injected write failure',
+            );
+
+            // Ownership must be unchanged (UPDATE rolled back).
+            const found = await findProjectById(db, project.id);
+            expect(found?.owner_id).toBe(testUser.id);
+
+            // New owner must still be a collaborator (removeCollaborator rolled back).
+            expect(await isCollaborator(db, project.id, newOwner.id)).toBe(true);
+
+            // Previous owner must NOT have been added as a collaborator
+            // (addCollaborator rolled back).
+            expect(await isCollaborator(db, project.id, testUser.id)).toBe(false);
+
+            // Collaborator set is exactly what it was before the failed transfer.
+            const collaborators = await getProjectCollaborators(db, project.id);
+            expect(collaborators.length).toBe(1);
+            expect(collaborators[0].id).toBe(newOwner.id);
+        });
     });
 
     // ============================================================================

--- a/src/db/queries/projects.ts
+++ b/src/db/queries/projects.ts
@@ -533,46 +533,52 @@ export async function transferOwnership(
     projectId: number,
     newOwnerId: number,
 ): Promise<TransferOwnershipResult> {
-    // 1. Get current project to find previous owner
-    const project = await findProjectById(db, projectId);
-    if (!project) {
-        throw new Error('Project not found');
-    }
+    // Wrap read-verify and all writes in a single transaction so the multi-row
+    // mutation (remove collaborator + add collaborator + update owner_id) either
+    // fully commits or fully rolls back. A mid-sequence failure must never leave
+    // inconsistent ownership state.
+    return db.transaction().execute(async trx => {
+        // 1. Get current project to find previous owner
+        const project = await findProjectById(trx, projectId);
+        if (!project) {
+            throw new Error('Project not found');
+        }
 
-    const previousOwnerId = project.owner_id;
+        const previousOwnerId = project.owner_id;
 
-    // 2. Cannot transfer to self
-    if (previousOwnerId === newOwnerId) {
-        throw new Error('Cannot transfer ownership to current owner');
-    }
+        // 2. Cannot transfer to self
+        if (previousOwnerId === newOwnerId) {
+            throw new Error('Cannot transfer ownership to current owner');
+        }
 
-    // 3. Verify new owner is a collaborator
-    const newOwnerIsCollaborator = await isCollaborator(db, projectId, newOwnerId);
-    if (!newOwnerIsCollaborator) {
-        throw new Error('New owner must be a current collaborator');
-    }
+        // 3. Verify new owner is a collaborator
+        const newOwnerIsCollaborator = await isCollaborator(trx, projectId, newOwnerId);
+        if (!newOwnerIsCollaborator) {
+            throw new Error('New owner must be a current collaborator');
+        }
 
-    // 4. Remove new owner from collaborators (they become owner)
-    await removeCollaborator(db, projectId, newOwnerId);
+        // 4. Remove new owner from collaborators (they become owner)
+        await removeCollaborator(trx, projectId, newOwnerId);
 
-    // 5. Add previous owner as collaborator
-    await addCollaborator(db, projectId, previousOwnerId);
+        // 5. Add previous owner as collaborator
+        await addCollaborator(trx, projectId, previousOwnerId);
 
-    // 6. Update owner_id
-    await db
-        .updateTable('projects')
-        .set({
-            owner_id: newOwnerId,
-            updated_at: now(),
-        })
-        .where('id', '=', projectId)
-        .execute();
+        // 6. Update owner_id
+        await trx
+            .updateTable('projects')
+            .set({
+                owner_id: newOwnerId,
+                updated_at: now(),
+            })
+            .where('id', '=', projectId)
+            .execute();
 
-    return {
-        success: true,
-        previousOwnerId,
-        newOwnerId,
-    };
+        return {
+            success: true,
+            previousOwnerId,
+            newOwnerId,
+        };
+    });
 }
 
 /**

--- a/src/db/queries/yjs.spec.ts
+++ b/src/db/queries/yjs.spec.ts
@@ -628,7 +628,9 @@ describe('Yjs Queries', () => {
                 const newState = new Uint8Array([10, 20, 30]);
                 const update = await saveFullState(db, testProjectId, newState, 'client-1');
 
-                expect(update.version).toBe('1');
+                // Version is a monotonic millisecond timestamp, not the old
+                // hardcoded '1' (which got filtered out below newer snapshots).
+                expect(/^\d{10,}$/.test(update.version)).toBe(true);
                 expect(update.update_data).toEqual(newState);
                 expect(update.client_id).toBe('client-1');
 
@@ -641,6 +643,21 @@ describe('Yjs Queries', () => {
                 const update = await saveFullState(db, testProjectId, state);
 
                 expect(update.client_id).toBeNull();
+            });
+
+            it('writes a version newer than an existing snapshot so the update is not filtered out (C6)', async () => {
+                // Simulate a browser save: a snapshot stamped with an earlier timestamp.
+                const snapshotVersion = (Date.now() - 1000).toString();
+                await upsertSnapshot(db, testProjectId, new Uint8Array([9]), snapshotVersion);
+
+                // A REST-API-style full-state save must land AFTER the snapshot.
+                await saveFullState(db, testProjectId, new Uint8Array([10, 20, 30]), 'client-1');
+
+                const { snapshot, updates } = await loadDocumentWithUpdates(db, testProjectId);
+                expect(snapshot?.snapshot_version).toBe(snapshotVersion);
+                // The full-state update must survive the snapshot-version filter.
+                expect(updates.length).toBe(1);
+                expect(parseInt(updates[0].version, 10)).toBeGreaterThan(parseInt(snapshotVersion, 10));
             });
         });
 

--- a/src/db/queries/yjs.ts
+++ b/src/db/queries/yjs.ts
@@ -6,10 +6,24 @@
 import { sql, type Kysely } from 'kysely';
 import type { Database, YjsDocument, NewYjsDocument, YjsUpdate, NewYjsUpdate, YjsVersionHistory } from '../types';
 import { now } from '../types';
-import { supportsReturning, updateByColumnAndReturn, toBinaryData } from '../helpers';
+import { getDialect, supportsReturning, updateByColumnAndReturn, toBinaryData } from '../helpers';
 
-/** version column is varchar — cast for numeric operations */
-const versionAsInt = sql<number>`CAST(version AS INTEGER)`;
+/**
+ * The `version` column is a varchar holding a numeric value. Versions are
+ * millisecond timestamps (Date.now()), which exceed a 32-bit INTEGER, so the
+ * cast must be dialect-aware: bare `INTEGER` overflows on PostgreSQL and is
+ * rejected by MySQL (which needs SIGNED). SQLite's INTEGER is 64-bit and fine.
+ */
+function versionAsInt() {
+    switch (getDialect()) {
+        case 'mysql':
+            return sql<number>`CAST(version AS SIGNED)`;
+        case 'postgres':
+            return sql<number>`CAST(version AS BIGINT)`;
+        default:
+            return sql<number>`CAST(version AS INTEGER)`;
+    }
+}
 
 // ============================================================================
 // YJS DOCUMENTS (SNAPSHOTS)
@@ -114,7 +128,7 @@ export async function findUpdatesByProjectId(db: Kysely<Database>, projectId: nu
         .selectFrom('yjs_updates')
         .selectAll()
         .where('project_id', '=', projectId)
-        .orderBy(versionAsInt, 'asc')
+        .orderBy(versionAsInt(), 'asc')
         .execute();
 }
 
@@ -128,8 +142,8 @@ export async function findUpdatesSince(
         .selectFrom('yjs_updates')
         .selectAll()
         .where('project_id', '=', projectId)
-        .where(versionAsInt, '>', sinceVersionNum)
-        .orderBy(versionAsInt, 'asc')
+        .where(versionAsInt(), '>', sinceVersionNum)
+        .orderBy(versionAsInt(), 'asc')
         .execute();
 }
 
@@ -171,7 +185,7 @@ export async function deleteUpdatesBefore(
     const result = await db
         .deleteFrom('yjs_updates')
         .where('project_id', '=', projectId)
-        .where(versionAsInt, '<', beforeVersionNum)
+        .where(versionAsInt(), '<', beforeVersionNum)
         .execute();
     return Number(result[0]?.numDeletedRows ?? 0);
 }
@@ -179,7 +193,7 @@ export async function deleteUpdatesBefore(
 export async function getLatestVersion(db: Kysely<Database>, projectId: number): Promise<string> {
     const result = await db
         .selectFrom('yjs_updates')
-        .select(sql<number>`MAX(${versionAsInt})`.as('maxVersion'))
+        .select(sql<number>`MAX(${versionAsInt()})`.as('maxVersion'))
         .where('project_id', '=', projectId)
         .executeTakeFirst();
 
@@ -214,15 +228,24 @@ export async function saveFullState(
     state: Uint8Array,
     clientId?: string,
 ): Promise<YjsUpdate> {
-    // Delete all existing updates for this project
-    await deleteAllUpdates(db, projectId);
+    // Use a monotonic millisecond-timestamp version (same scheme as snapshots
+    // and incremental updates) so loadDocumentWithUpdates does NOT filter this
+    // write out as "older than the snapshot". The previous hardcoded '1' was
+    // always < a Date.now() snapshot version, which silently discarded every
+    // REST API v1 edit on reload (C6).
+    const version = Date.now().toString();
 
-    // Save new full state as version 1
-    return createUpdate(db, {
-        project_id: projectId,
-        update_data: state,
-        version: '1',
-        client_id: clientId || null,
+    // Replace prior updates and insert the new full state ATOMICALLY. The old
+    // delete-then-insert was non-transactional: a failed insert left the prior
+    // row already deleted, losing all server-side state (H6).
+    return db.transaction().execute(async trx => {
+        await deleteAllUpdates(trx, projectId);
+        return createUpdate(trx, {
+            project_id: projectId,
+            update_data: state,
+            version,
+            client_id: clientId || null,
+        });
     });
 }
 
@@ -282,8 +305,8 @@ export async function getUpdateStats(db: Kysely<Database>, projectId: number): P
             eb.fn.count<number>('id').as('count'),
             eb.fn.sum<number>(eb.fn('length', ['update_data'])).as('totalBytes'),
         ])
-        .select(sql<number>`MIN(${versionAsInt})`.as('oldestVersion'))
-        .select(sql<number>`MAX(${versionAsInt})`.as('newestVersion'))
+        .select(sql<number>`MIN(${versionAsInt()})`.as('oldestVersion'))
+        .select(sql<number>`MAX(${versionAsInt()})`.as('newestVersion'))
         .where('project_id', '=', projectId)
         .executeTakeFirst();
 
@@ -365,7 +388,7 @@ export async function deleteUpdatesUpToVersion(
     const result = await db
         .deleteFrom('yjs_updates')
         .where('project_id', '=', projectId)
-        .where(versionAsInt, '<=', upToVersionNum)
+        .where(versionAsInt(), '<=', upToVersionNum)
         .execute();
     return Number(result[0]?.numDeletedRows ?? 0);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,11 @@ import { staticPlugin } from '@elysiajs/static';
 import { healthRoutes, healthCheckAlias } from './routes/health';
 import { authRoutes } from './routes/auth';
 import { projectRoutes, symfonyCompatProjectRoutes } from './routes/project';
-import { assetsRoutes } from './routes/assets';
+import { assetsRoutes, startChunkUploadSweeper, stopChunkUploadSweeper } from './routes/assets';
+import {
+    startCleanupScheduler as startUploadSessionCleanup,
+    stopCleanupScheduler as stopUploadSessionCleanup,
+} from './services/upload-session-manager';
 import { fileManagerRoutes } from './routes/filemanager';
 import { exportRoutes } from './routes/export';
 import { convertRoutes } from './routes/convert';
@@ -812,6 +816,11 @@ async function bootstrap() {
     // 7. Start cleanup scheduler (for unsaved and guest projects)
     startCleanupScheduler(getCleanupConfigFromEnv());
 
+    // 7b. Start resource-bound sweepers: reap abandoned chunked uploads and
+    // expired upload sessions so neither disk nor memory grows unbounded.
+    startChunkUploadSweeper();
+    startUploadSessionCleanup();
+
     console.log(`Elysia server running at http://localhost:${PORT}`);
     console.log(`Pages: /login, /workarea`);
     console.log(`Auth endpoints: /api/auth/login, /api/auth/logout, /api/session/check`);
@@ -831,6 +840,8 @@ async function gracefulShutdown(signal: string) {
     console.log(`${signal} received, shutting down...`);
     stopWebSocket();
     stopCleanupScheduler();
+    stopChunkUploadSweeper();
+    stopUploadSessionCleanup();
     await disconnectRedis();
     await closeDb();
     process.exit(0);

--- a/src/routes/admin-templates.spec.ts
+++ b/src/routes/admin-templates.spec.ts
@@ -12,14 +12,26 @@ import type { Template } from '../db/types';
 const TEST_JWT_SECRET = 'test-secret-for-admin-templates';
 
 // Store original env
+let originalApiJwtSecret: string | undefined;
 let originalJwtSecret: string | undefined;
 
 beforeAll(() => {
+    // The canonical resolver (auth.ts:getJwtSecret) prefers API_JWT_SECRET over
+    // JWT_SECRET, and the test env sets API_JWT_SECRET via .env, so we must override
+    // API_JWT_SECRET to the value tokens are signed with. beforeAll runs before any
+    // beforeEach (where routes are created), so the secret resolves from this value.
+    originalApiJwtSecret = process.env.API_JWT_SECRET;
     originalJwtSecret = process.env.JWT_SECRET;
+    process.env.API_JWT_SECRET = TEST_JWT_SECRET;
     process.env.JWT_SECRET = TEST_JWT_SECRET;
 });
 
 afterAll(() => {
+    if (originalApiJwtSecret === undefined) {
+        delete process.env.API_JWT_SECRET;
+    } else {
+        process.env.API_JWT_SECRET = originalApiJwtSecret;
+    }
     if (originalJwtSecret === undefined) {
         delete process.env.JWT_SECRET;
     } else {

--- a/src/routes/admin-themes.spec.ts
+++ b/src/routes/admin-themes.spec.ts
@@ -12,14 +12,26 @@ import type { Theme } from '../db/types';
 const TEST_JWT_SECRET = 'test-secret-for-admin-themes';
 
 // Store original env
+let originalApiJwtSecret: string | undefined;
 let originalJwtSecret: string | undefined;
 
 beforeAll(() => {
+    // The canonical resolver (auth.ts:getJwtSecret) prefers API_JWT_SECRET over
+    // JWT_SECRET, and the test env sets API_JWT_SECRET via .env, so we must override
+    // API_JWT_SECRET to the value tokens are signed with. beforeAll runs before any
+    // beforeEach (where routes are created), so the secret resolves from this value.
+    originalApiJwtSecret = process.env.API_JWT_SECRET;
     originalJwtSecret = process.env.JWT_SECRET;
+    process.env.API_JWT_SECRET = TEST_JWT_SECRET;
     process.env.JWT_SECRET = TEST_JWT_SECRET;
 });
 
 afterAll(() => {
+    if (originalApiJwtSecret === undefined) {
+        delete process.env.API_JWT_SECRET;
+    } else {
+        process.env.API_JWT_SECRET = originalApiJwtSecret;
+    }
     if (originalJwtSecret === undefined) {
         delete process.env.JWT_SECRET;
     } else {

--- a/src/routes/admin.spec.ts
+++ b/src/routes/admin.spec.ts
@@ -151,11 +151,16 @@ const createMockDeps = (
     getConnectedClientsDetail: getConnectedClientsDetailOverride,
 });
 
+// Sign tokens with the same value the canonical resolver (auth.ts:getJwtSecret)
+// returns at verify time. beforeEach sets API_JWT_SECRET to this value, which the
+// resolver prefers over JWT_SECRET, so signing and verification stay aligned (H3).
+const TEST_JWT_SECRET = 'test-secret';
+
 // Helper to generate admin JWT token
 async function generateAdminToken(): Promise<string> {
     const jwtInstance = jwt({
         name: 'jwt',
-        secret: process.env.JWT_SECRET || 'test-secret',
+        secret: TEST_JWT_SECRET,
     });
     const tempApp = new Elysia().use(jwtInstance);
 
@@ -171,7 +176,7 @@ async function generateAdminToken(): Promise<string> {
 async function generateUserToken(): Promise<string> {
     const jwtInstance = jwt({
         name: 'jwt',
-        secret: process.env.JWT_SECRET || 'test-secret',
+        secret: TEST_JWT_SECRET,
     });
     const tempApp = new Elysia().use(jwtInstance);
 
@@ -191,7 +196,11 @@ describe('Admin Routes', () => {
     const originalEnv = { ...process.env };
 
     beforeEach(() => {
-        process.env.JWT_SECRET = 'test-secret';
+        // Resolver prefers API_JWT_SECRET, so set it (not just JWT_SECRET) to the
+        // value tokens are signed with. Routes are created inside each test, after
+        // this hook runs, so the secret is resolved from this value.
+        process.env.API_JWT_SECRET = TEST_JWT_SECRET;
+        process.env.JWT_SECRET = TEST_JWT_SECRET;
     });
 
     afterEach(() => {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -13,7 +13,7 @@ import { invalidateMaintenanceCache } from '../services/maintenance';
 import type { Kysely } from 'kysely';
 import type { Database, User } from '../db/types';
 import { parseRoles } from '../db/types';
-import type { JwtPayload } from './auth';
+import { getJwtSecret, type JwtPayload } from './auth';
 import {
     findUserById as findUserByIdDefault,
     findUsersByIds as findUsersByIdsDefault,
@@ -151,11 +151,6 @@ const defaultDependencies: AdminDependencies = {
     },
     fileHelper: createFileHelper(),
     getConnectedClientsDetail: getConnectedClientsDetail,
-};
-
-// Get JWT secret (same as auth.ts)
-const getJwtSecret = () => {
-    return process.env.JWT_SECRET || process.env.APP_SECRET || 'elysia-dev-secret-change-me';
 };
 
 // ============================================================================

--- a/src/routes/api/v1/assets.spec.ts
+++ b/src/routes/api/v1/assets.spec.ts
@@ -370,6 +370,86 @@ describe('Assets API v1', () => {
             expect(body.success).toBe(true);
             expect(body.data.filename).toBe('new.png');
         });
+
+        it('should reject a path-traversal clientId with 400 and write nothing to disk', async () => {
+            await db
+                .insertInto('projects')
+                .values({
+                    uuid: 'user-project-traversal',
+                    title: 'User Project',
+                    owner_id: userId,
+                    created_at: now(),
+                })
+                .execute();
+
+            // Sentinel target the traversal would attempt to overwrite if unguarded.
+            const escapeTarget = path.join(TEST_FILES_DIR, 'pwned.txt');
+            await fs.remove(escapeTarget).catch(() => {});
+
+            const formData = new FormData();
+            // No extension on the filename gives ext '', so without the guard this
+            // would resolve to TEST_FILES_DIR/pwned.txt — path.join collapses the `..`.
+            formData.append('file', new Blob(['malicious'], { type: 'text/plain' }), 'noext');
+            formData.append('clientId', '../../pwned.txt');
+
+            const response = await app.handle(
+                new Request('http://localhost/projects/user-project-traversal/assets', {
+                    method: 'POST',
+                    headers: { Authorization: `Bearer ${userToken}` },
+                    body: formData,
+                }),
+            );
+
+            expect(response.status).toBe(400);
+            const body = (await response.json()) as { success: boolean; error: { code: string } };
+            expect(body.success).toBe(false);
+            expect(body.error.code).toBe('BAD_REQUEST');
+
+            // Nothing was written outside (or inside) the project assets directory.
+            expect(await fs.pathExists(escapeTarget)).toBe(false);
+            const assetsDir = path.join(TEST_FILES_DIR, 'assets', 'user-project-traversal');
+            const entries = (await fs.pathExists(assetsDir)) ? await fs.readdir(assetsDir) : [];
+            expect(entries.length).toBe(0);
+
+            // And no asset record was created.
+            const rows = await db.selectFrom('assets').selectAll().execute();
+            expect(rows.length).toBe(0);
+        });
+
+        it('should upload successfully with a normal UUID clientId', async () => {
+            await db
+                .insertInto('projects')
+                .values({
+                    uuid: 'user-project-uuid-clientid',
+                    title: 'User Project',
+                    owner_id: userId,
+                    created_at: now(),
+                })
+                .execute();
+
+            const clientId = '123e4567-e89b-12d3-a456-426614174000';
+            const formData = new FormData();
+            formData.append('file', new Blob(['safe content'], { type: 'image/png' }), 'safe.png');
+            formData.append('clientId', clientId);
+
+            const response = await app.handle(
+                new Request('http://localhost/projects/user-project-uuid-clientid/assets', {
+                    method: 'POST',
+                    headers: { Authorization: `Bearer ${userToken}` },
+                    body: formData,
+                }),
+            );
+
+            expect(response.status).toBe(201);
+            const body = (await response.json()) as { success: boolean; data: { clientId: string; filename: string } };
+            expect(body.success).toBe(true);
+            expect(body.data.clientId).toBe(clientId);
+            expect(body.data.filename).toBe('safe.png');
+
+            // File is stored as {clientId}.{ext} inside the project assets directory.
+            const expectedPath = path.join(TEST_FILES_DIR, 'assets', 'user-project-uuid-clientid', `${clientId}.png`);
+            expect(await fs.pathExists(expectedPath)).toBe(true);
+        });
     });
 
     describe('GET /projects/:uuid/assets/:assetId', () => {

--- a/src/routes/api/v1/assets.ts
+++ b/src/routes/api/v1/assets.ts
@@ -7,7 +7,6 @@
  * Changes are automatically broadcast to WebSocket clients.
  */
 import { Elysia, t } from 'elysia';
-import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import * as fs from 'fs-extra';
 
@@ -25,6 +24,7 @@ import {
 } from '../../../db/queries';
 import type { Asset } from '../../../db/types';
 import { getProjectAssetsDir, fileExists, readFile, remove } from '../../../services/file-helper';
+import { isSafePathSegment, safeJoin, sanitizeFileExtension } from '../../../utils/safe-path';
 import { withDocument, setAssetMetadata, deleteAssetMetadata, type AssetMetadata } from '../../../yjs';
 import {
     authenticateRequest,
@@ -182,6 +182,11 @@ export const assetsRoutes = new Elysia({ prefix: '/projects' })
 
             const file = data.file;
             const clientId = data.clientId || uuidv4();
+            // clientId becomes the on-disk filename; reject traversal/separators.
+            if (!isSafePathSegment(clientId)) {
+                set.status = 400;
+                return errorResponse('BAD_REQUEST', 'Invalid clientId');
+            }
             const folderPath = sanitizeFolderPath(data.folderPath);
 
             // Get file data
@@ -206,9 +211,9 @@ export const assetsRoutes = new Elysia({ prefix: '/projects' })
             const baseStoragePath = getProjectAssetsDir(params.uuid);
             await fs.ensureDir(baseStoragePath);
 
-            const ext = path.extname(filename).toLowerCase();
+            const ext = sanitizeFileExtension(filename);
             const flatFilename = `${clientId}${ext}`;
-            const filePath = path.join(baseStoragePath, flatFilename);
+            const filePath = safeJoin(baseStoragePath, flatFilename);
 
             // Write file
             if (typeof Bun !== 'undefined' && Bun.write) {

--- a/src/routes/assets.spec.ts
+++ b/src/routes/assets.spec.ts
@@ -378,6 +378,106 @@ describe('Assets Routes', () => {
         });
     });
 
+    describe('path traversal protection (clientId / resumableIdentifier as on-disk names)', () => {
+        const TRAVERSAL = '../../../../tmp/pwned';
+
+        it('rejects a traversal clientId on simple upload with 400', async () => {
+            const formData = new FormData();
+            formData.append('file', new Blob(['x'], { type: 'text/plain' }), 'test.txt');
+            formData.append('clientId', TRAVERSAL);
+
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets`, { method: 'POST', body: formData }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.success).toBe(false);
+            expect(body.error).toContain('Invalid clientId');
+            // Nothing should have been written/created.
+            expect(mockAssets.size).toBe(0);
+        });
+
+        it('rejects a traversal resumableIdentifier on chunk upload with 400', async () => {
+            const formData = new FormData();
+            formData.append('file', new Blob(['chunk'], { type: 'application/octet-stream' }));
+            formData.append('resumableIdentifier', TRAVERSAL);
+            formData.append('resumableChunkNumber', '1');
+            formData.append('resumableTotalChunks', '1');
+
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets/upload-chunk`, {
+                    method: 'POST',
+                    body: formData,
+                }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.error).toContain('Invalid identifier');
+        });
+
+        it('rejects a traversal clientId on chunk finalize with 400', async () => {
+            const formData = new FormData();
+            formData.append('resumableIdentifier', 'some-id');
+            formData.append('clientId', TRAVERSAL);
+
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets/upload-chunk/finalize`, {
+                    method: 'POST',
+                    body: formData,
+                }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.error).toContain('Invalid clientId');
+        });
+
+        it('rejects a traversal clientId inside /sync metadata with 400', async () => {
+            const formData = new FormData();
+            formData.append('files', new Blob(['x'], { type: 'text/plain' }), 'a.txt');
+            formData.append(
+                'metadata',
+                JSON.stringify([{ clientId: TRAVERSAL, filename: 'a.txt', mimeType: 'text/plain' }]),
+            );
+
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets/sync`, { method: 'POST', body: formData }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.error).toContain('Invalid clientId');
+        });
+
+        it('rejects a traversal x-client-id header on /stream with 400', async () => {
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets/stream`, {
+                    method: 'POST',
+                    headers: { 'x-client-id': TRAVERSAL, 'content-type': 'application/octet-stream' },
+                    body: 'streamed-bytes',
+                }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.error).toContain('Invalid clientId');
+        });
+
+        it('still accepts a normal UUID-style clientId', async () => {
+            const formData = new FormData();
+            formData.append('file', new Blob(['ok'], { type: 'text/plain' }), 'ok.txt');
+            formData.append('clientId', '550e8400-e29b-41d4-a716-446655440000');
+
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets`, { method: 'POST', body: formData }),
+            );
+
+            expect(res.status).toBe(200);
+        });
+    });
+
     describe('GET /api/projects/:projectId/assets - List Assets', () => {
         it('should return empty array for project with no assets', async () => {
             const res = await handle(new Request(`http://localhost/api/projects/1/assets`));

--- a/src/routes/assets.spec.ts
+++ b/src/routes/assets.spec.ts
@@ -9,6 +9,13 @@ import { Elysia } from 'elysia';
 import { SignJWT } from 'jose';
 import {
     createAssetsRoutes,
+    sweepStaleChunkUploads,
+    startChunkUploadSweeper,
+    stopChunkUploadSweeper,
+    __getChunkUploadsForTest,
+    CHUNK_UPLOAD_TTL_MS,
+    MAX_TOTAL_CHUNKS,
+    MAX_CHUNK_BYTES,
     type AssetsDependencies,
     type AssetsFileHelperDeps,
     type AssetsSessionManagerDeps,
@@ -1607,5 +1614,292 @@ describe('Assets Routes', () => {
             );
             expect(res.status).toBe(403);
         });
+    });
+});
+
+// =====================================================
+// BUG H9: abandoned chunked-upload leak + size caps
+// =====================================================
+describe('Chunked upload leak/limit fix (BUG H9)', () => {
+    const chunkUploads = __getChunkUploadsForTest();
+
+    beforeEach(() => {
+        chunkUploads.clear();
+        stopChunkUploadSweeper();
+    });
+
+    afterEach(() => {
+        chunkUploads.clear();
+        stopChunkUploadSweeper();
+    });
+
+    describe('sweepStaleChunkUploads', () => {
+        it('removes entries older than the TTL and leaves fresh ones', () => {
+            const now = Date.now();
+
+            // Stale entry: createdAt well beyond the TTL.
+            chunkUploads.set('proj:stale', {
+                projectId: 'proj',
+                filename: 'stale.zip',
+                totalChunks: 2,
+                uploadedChunks: new Set([1]),
+                chunkDir: path.join(testDir, 'chunks', 'proj', 'stale'),
+                createdAt: new Date(now - CHUNK_UPLOAD_TTL_MS - 60_000),
+                initialized: false,
+            });
+
+            // Fresh entry: created just now.
+            chunkUploads.set('proj:fresh', {
+                projectId: 'proj',
+                filename: 'fresh.zip',
+                totalChunks: 2,
+                uploadedChunks: new Set([1]),
+                chunkDir: path.join(testDir, 'chunks', 'proj', 'fresh'),
+                createdAt: new Date(now),
+                initialized: false,
+            });
+
+            const swept = sweepStaleChunkUploads(now, CHUNK_UPLOAD_TTL_MS);
+
+            expect(swept).toBe(1);
+            expect(chunkUploads.has('proj:stale')).toBe(false);
+            expect(chunkUploads.has('proj:fresh')).toBe(true);
+        });
+
+        it('deletes the on-disk chunk directory of swept entries', async () => {
+            const now = Date.now();
+            const chunkDir = path.join(testDir, 'chunks', 'proj', 'stale-disk');
+            await fs.ensureDir(chunkDir);
+            await fs.writeFile(path.join(chunkDir, 'chunk_1'), 'data');
+            expect(await fs.pathExists(chunkDir)).toBe(true);
+
+            chunkUploads.set('proj:stale-disk', {
+                projectId: 'proj',
+                filename: 'stale.zip',
+                totalChunks: 1,
+                uploadedChunks: new Set([1]),
+                chunkDir,
+                createdAt: new Date(now - CHUNK_UPLOAD_TTL_MS - 1),
+                initialized: true,
+            });
+
+            const swept = sweepStaleChunkUploads(now, CHUNK_UPLOAD_TTL_MS);
+            expect(swept).toBe(1);
+
+            // fs.remove runs async; wait until the directory is gone.
+            await new Promise<void>((resolve, reject) => {
+                let attempts = 0;
+                const tick = async () => {
+                    if (!(await fs.pathExists(chunkDir))) return resolve();
+                    if (++attempts > 50) return reject(new Error('chunk dir was not removed'));
+                    setTimeout(tick, 10);
+                };
+                void tick();
+            });
+
+            expect(await fs.pathExists(chunkDir)).toBe(false);
+        });
+
+        it('returns 0 when nothing is stale', () => {
+            chunkUploads.set('proj:fresh', {
+                projectId: 'proj',
+                filename: 'fresh.zip',
+                totalChunks: 1,
+                uploadedChunks: new Set([1]),
+                chunkDir: path.join(testDir, 'chunks', 'proj', 'fresh'),
+                createdAt: new Date(),
+                initialized: false,
+            });
+
+            expect(sweepStaleChunkUploads(Date.now(), CHUNK_UPLOAD_TTL_MS)).toBe(0);
+            expect(chunkUploads.has('proj:fresh')).toBe(true);
+        });
+    });
+
+    describe('startChunkUploadSweeper / stopChunkUploadSweeper', () => {
+        it('runs the sweep on its interval and stops cleanly', async () => {
+            const now = Date.now();
+            chunkUploads.set('proj:stale', {
+                projectId: 'proj',
+                filename: 'stale.zip',
+                totalChunks: 1,
+                uploadedChunks: new Set([1]),
+                chunkDir: path.join(testDir, 'chunks', 'proj', 'interval-stale'),
+                createdAt: new Date(now - CHUNK_UPLOAD_TTL_MS - 60_000),
+                initialized: false,
+            });
+
+            // Tiny interval so the timer fires quickly under test.
+            startChunkUploadSweeper(5);
+            // Starting twice is a no-op (idempotent) and must not throw.
+            startChunkUploadSweeper(5);
+
+            await new Promise<void>((resolve, reject) => {
+                let attempts = 0;
+                const tick = () => {
+                    if (!chunkUploads.has('proj:stale')) return resolve();
+                    if (++attempts > 100) return reject(new Error('sweeper did not run'));
+                    setTimeout(tick, 5);
+                };
+                tick();
+            });
+
+            expect(chunkUploads.has('proj:stale')).toBe(false);
+
+            // stop is idempotent and must not throw.
+            stopChunkUploadSweeper();
+            stopChunkUploadSweeper();
+        });
+    });
+});
+
+// =====================================================
+// BUG H9: chunk size caps enforced by the upload route
+// =====================================================
+describe('Chunked upload size caps (BUG H9)', () => {
+    let app: Elysia;
+    let mockAssets: Map<number, any>;
+    let mockProjects: Map<string, any>;
+    let assetIdCounter: number;
+    let ownerToken: string;
+
+    function buildDeps(): AssetsDependencies {
+        return {
+            db: {} as any,
+            queries: {
+                createAsset: async (_db: any, data: any) => {
+                    const id = assetIdCounter++;
+                    const asset = { id, ...data, created_at: '', updated_at: '' };
+                    mockAssets.set(id, asset);
+                    return asset;
+                },
+                createAssets: async (_db: any, arr: any[]) => arr.map(d => ({ id: assetIdCounter++, ...d })),
+                findAssetById: async (_db: any, id: number) => mockAssets.get(id),
+                findAllAssetsForProject: async () => [],
+                findAssetByClientId: async () => undefined,
+                findAssetsByClientIds: async () => [],
+                deleteAsset: async () => {},
+                updateAsset: async () => undefined,
+                bulkUpdateAssets: async () => {},
+                findProjectByUuid: async (_db: any, uuid: string) => mockProjects.get(uuid),
+                findProjectById: async (_db: any, id: number) => {
+                    for (const p of mockProjects.values()) if (p.id === id) return p;
+                    return undefined;
+                },
+                checkProjectAccess: async (_db: any, project: any, userId?: number) => {
+                    if (!project) return { hasAccess: false, reason: 'PROJECT_NOT_FOUND' };
+                    if (project.owner_id === userId) return { hasAccess: true };
+                    return { hasAccess: false, reason: 'ACCESS_DENIED' };
+                },
+            },
+            fileHelper: createMockFileHelper(),
+            sessionManager: createMockSessionManager(),
+            priorityQueue: createMockPriorityQueue(),
+        };
+    }
+
+    beforeAll(async () => {
+        ownerToken = await signTestToken(OWNER_USER_ID);
+    });
+
+    beforeEach(async () => {
+        mockAssets = new Map();
+        mockProjects = new Map();
+        mockSessions = new Map();
+        assetIdCounter = 1;
+        mockProjects.set(testProjectId, {
+            id: 1,
+            uuid: testProjectId,
+            owner_id: OWNER_USER_ID,
+            visibility: 'private',
+            status: 'active',
+        });
+        app = new Elysia().use(createAssetsRoutes(buildDeps()));
+        __getChunkUploadsForTest().clear();
+        await fs.ensureDir(path.join(testDir, 'assets', testProjectId));
+    });
+
+    afterEach(async () => {
+        __getChunkUploadsForTest().clear();
+        if (await fs.pathExists(testDir)) {
+            await fs.remove(testDir);
+        }
+    });
+
+    async function authPost(url: string, body: FormData): Promise<Response> {
+        return app.handle(
+            new Request(url, {
+                method: 'POST',
+                body,
+                headers: { Authorization: `Bearer ${ownerToken}` },
+            }),
+        );
+    }
+
+    it('rejects a chunk larger than MAX_CHUNK_BYTES with 413', async () => {
+        const tooBig = new Uint8Array(MAX_CHUNK_BYTES + 1);
+        const formData = new FormData();
+        formData.append('file', new Blob([tooBig], { type: 'application/octet-stream' }));
+        formData.append('resumableIdentifier', 'oversize-upload');
+        formData.append('resumableChunkNumber', '1');
+        formData.append('resumableTotalChunks', '1');
+        formData.append('resumableFilename', 'huge.bin');
+
+        const res = await authPost('http://localhost/api/projects/1/assets/upload-chunk', formData);
+
+        expect(res.status).toBe(413);
+        const json = await res.json();
+        expect(json.success).toBe(false);
+        expect(json.error).toContain('maximum allowed size');
+        // No tracking state should have been created.
+        expect(__getChunkUploadsForTest().has('1:oversize-upload')).toBe(false);
+    });
+
+    it('rejects an absurd resumableTotalChunks above MAX_TOTAL_CHUNKS with 400', async () => {
+        const formData = new FormData();
+        formData.append('file', new Blob(['small'], { type: 'application/octet-stream' }));
+        formData.append('resumableIdentifier', 'absurd-total');
+        formData.append('resumableChunkNumber', '1');
+        formData.append('resumableTotalChunks', String(MAX_TOTAL_CHUNKS + 1));
+        formData.append('resumableFilename', 'evil.bin');
+
+        const res = await authPost('http://localhost/api/projects/1/assets/upload-chunk', formData);
+
+        expect(res.status).toBe(400);
+        const json = await res.json();
+        expect(json.success).toBe(false);
+        expect(json.error).toContain('Invalid resumableTotalChunks');
+        expect(__getChunkUploadsForTest().has('1:absurd-total')).toBe(false);
+    });
+
+    it('rejects a non-numeric resumableTotalChunks with 400', async () => {
+        const formData = new FormData();
+        formData.append('file', new Blob(['small'], { type: 'application/octet-stream' }));
+        formData.append('resumableIdentifier', 'nan-total');
+        formData.append('resumableChunkNumber', '1');
+        formData.append('resumableTotalChunks', 'not-a-number');
+        formData.append('resumableFilename', 'evil.bin');
+
+        const res = await authPost('http://localhost/api/projects/1/assets/upload-chunk', formData);
+
+        expect(res.status).toBe(400);
+        const json = await res.json();
+        expect(json.error).toContain('Invalid resumableTotalChunks');
+    });
+
+    it('accepts a normal small chunk within the caps', async () => {
+        const formData = new FormData();
+        formData.append('file', new Blob(['ok chunk'], { type: 'application/octet-stream' }));
+        formData.append('resumableIdentifier', 'normal-upload');
+        formData.append('resumableChunkNumber', '1');
+        formData.append('resumableTotalChunks', '2');
+        formData.append('resumableFilename', 'fine.bin');
+
+        const res = await authPost('http://localhost/api/projects/1/assets/upload-chunk', formData);
+
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json.success).toBe(true);
+        expect(__getChunkUploadsForTest().has('1:normal-upload')).toBe(true);
     });
 });

--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -165,19 +165,122 @@ const defaultDependencies: AssetsDependencies = {
     priorityQueue: defaultPriorityQueue,
 };
 
+/**
+ * Tracked state for a single in-progress chunked upload.
+ */
+interface ChunkUploadEntry {
+    projectId: string;
+    filename: string;
+    totalChunks: number;
+    uploadedChunks: Set<number>;
+    chunkDir: string;
+    createdAt: Date;
+    initialized: boolean; // Flag to track if directory has been created
+}
+
 // In-memory storage for chunked uploads
-const chunkUploads = new Map<
-    string,
-    {
-        projectId: string;
-        filename: string;
-        totalChunks: number;
-        uploadedChunks: Set<number>;
-        chunkDir: string;
-        createdAt: Date;
-        initialized: boolean; // Flag to track if directory has been created
+const chunkUploads = new Map<string, ChunkUploadEntry>();
+
+// =====================================================
+// Chunked upload limits & abandoned-upload sweeper (BUG H9)
+// =====================================================
+
+/**
+ * Maximum accepted size for a single uploaded chunk (20 MB).
+ * Prevents an attacker from writing arbitrarily large files via one chunk.
+ */
+export const MAX_CHUNK_BYTES = 20 * 1024 * 1024;
+
+/**
+ * Maximum number of chunks a single upload may declare (10000).
+ * Prevents an attacker from declaring an enormous chunk count that would
+ * never complete while keeping the Map entry and on-disk directory alive.
+ */
+export const MAX_TOTAL_CHUNKS = 10_000;
+
+/**
+ * Time-to-live for an in-progress chunked upload (1 hour). Uploads that are
+ * neither finalized nor explicitly cancelled within this window are considered
+ * abandoned and are reaped by the sweeper, freeing both the Map entry and the
+ * on-disk chunk directory.
+ */
+export const CHUNK_UPLOAD_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * How often the background sweeper runs (15 minutes).
+ */
+export const CHUNK_UPLOAD_SWEEP_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * Module-level handle for the background sweeper interval, if running.
+ */
+let chunkUploadSweeperHandle: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Remove abandoned chunked uploads whose `createdAt` is older than `ttlMs`.
+ * Deletes both the in-memory Map entry and the on-disk chunk directory.
+ * Pure-ish and directly callable so it can be unit tested without timers.
+ *
+ * @param now - Reference timestamp in ms (defaults to Date.now()).
+ * @param ttlMs - Maximum age before an upload is considered abandoned.
+ * @returns Number of upload entries swept.
+ */
+export function sweepStaleChunkUploads(now: number = Date.now(), ttlMs: number = CHUNK_UPLOAD_TTL_MS): number {
+    let swept = 0;
+    for (const [uploadKey, upload] of chunkUploads) {
+        const age = now - upload.createdAt.getTime();
+        if (age <= ttlMs) {
+            continue;
+        }
+        chunkUploads.delete(uploadKey);
+        swept += 1;
+        // Best-effort on-disk cleanup; ignore errors (dir may already be gone).
+        void fs.remove(upload.chunkDir).catch(() => {});
     }
->();
+    return swept;
+}
+
+/**
+ * Start the background sweeper that periodically reaps abandoned chunked
+ * uploads. Idempotent: a second call while running is a no-op. The interval is
+ * `unref()`'d (when available) so it never keeps the process alive on its own.
+ * The orchestrator (src/index.ts) is responsible for calling this on startup.
+ *
+ * @param intervalMs - Sweep cadence in ms (defaults to CHUNK_UPLOAD_SWEEP_INTERVAL_MS).
+ */
+export function startChunkUploadSweeper(intervalMs: number = CHUNK_UPLOAD_SWEEP_INTERVAL_MS): void {
+    if (chunkUploadSweeperHandle !== null) {
+        return;
+    }
+    chunkUploadSweeperHandle = setInterval(() => {
+        sweepStaleChunkUploads();
+    }, intervalMs);
+    // Avoid keeping the event loop (and the process) alive solely for sweeping.
+    if (typeof chunkUploadSweeperHandle.unref === 'function') {
+        chunkUploadSweeperHandle.unref();
+    }
+}
+
+/**
+ * Stop the background sweeper if it is running. Idempotent. The orchestrator
+ * (src/index.ts) is responsible for calling this on shutdown.
+ */
+export function stopChunkUploadSweeper(): void {
+    if (chunkUploadSweeperHandle === null) {
+        return;
+    }
+    clearInterval(chunkUploadSweeperHandle);
+    chunkUploadSweeperHandle = null;
+}
+
+/**
+ * Test-only accessor for the module-level chunkUploads Map. Lets specs seed
+ * entries, backdate `createdAt`, and assert on sweep behaviour without coupling
+ * to the HTTP layer. Not part of the public/runtime API surface.
+ */
+export function __getChunkUploadsForTest(): Map<string, ChunkUploadEntry> {
+    return chunkUploads;
+}
 
 /**
  * Factory function to create assets routes with injected dependencies
@@ -406,6 +509,31 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                         return { success: false, error: 'Invalid identifier' };
                     }
 
+                    // Reject an absurd / non-numeric declared chunk count up front. An attacker
+                    // could otherwise declare an enormous totalChunks so the upload can never be
+                    // finalized, leaving the Map entry and on-disk chunks around indefinitely.
+                    if (!Number.isInteger(totalChunks) || totalChunks < 1 || totalChunks > MAX_TOTAL_CHUNKS) {
+                        set.status = 400;
+                        return { success: false, error: 'Invalid resumableTotalChunks' };
+                    }
+
+                    // Resolve the chunk buffer early so we can enforce the per-chunk size cap
+                    // BEFORE creating any tracking state or touching disk.
+                    let chunkBuffer: Buffer;
+                    if (chunk instanceof Blob) {
+                        chunkBuffer = Buffer.from(await chunk.arrayBuffer());
+                    } else if (Buffer.isBuffer(chunk)) {
+                        chunkBuffer = chunk;
+                    } else {
+                        chunkBuffer = Buffer.from(chunk as ArrayBuffer | Uint8Array);
+                    }
+
+                    // Cap the size of an individual chunk to bound disk/memory usage.
+                    if (chunkBuffer.length > MAX_CHUNK_BYTES) {
+                        set.status = 413;
+                        return { success: false, error: 'Chunk exceeds maximum allowed size' };
+                    }
+
                     const uploadKey = `${projectId}:${identifier}`;
 
                     // Initialize upload tracking SYNCHRONOUSLY to prevent race condition
@@ -432,16 +560,6 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     if (!upload.initialized) {
                         await fs.ensureDir(upload.chunkDir);
                         upload.initialized = true;
-                    }
-
-                    // Get chunk buffer
-                    let chunkBuffer: Buffer;
-                    if (chunk instanceof Blob) {
-                        chunkBuffer = Buffer.from(await chunk.arrayBuffer());
-                    } else if (Buffer.isBuffer(chunk)) {
-                        chunkBuffer = chunk;
-                    } else {
-                        chunkBuffer = Buffer.from(chunk);
                     }
 
                     // Write chunk to disk using Bun.write for optimal performance

--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -43,6 +43,7 @@ import {
 import { getSession as getSessionDefault } from '../services/session-manager';
 import { serverPriorityQueue as serverPriorityQueueDefault } from '../services/asset-priority-queue';
 import type { AssetUploadRequest } from './types/request-payloads';
+import { isSafePathSegment, safeJoin, sanitizeFileExtension } from '../utils/safe-path';
 
 /**
  * File with optional name property (for Blob/File uploads)
@@ -269,6 +270,11 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     const componentId = data.componentId;
                     // Support clientId from form body OR query parameter (bulk upload uses query param)
                     const clientId = data.clientId || (query as { clientId?: string }).clientId || uuidv4();
+                    // clientId becomes the on-disk filename; reject traversal/separators.
+                    if (!isSafePathSegment(clientId)) {
+                        set.status = 400;
+                        return { success: false, error: 'Invalid clientId' };
+                    }
                     const folderPath = sanitizeFolderPath(data.folderPath);
 
                     // Get file data
@@ -296,9 +302,9 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     await fs.ensureDir(baseStoragePath);
 
                     // Use clientId as filename with original extension
-                    const ext = path.extname(filename).toLowerCase();
+                    const ext = sanitizeFileExtension(filename);
                     const flatFilename = `${clientId}${ext}`;
-                    const filePath = path.join(baseStoragePath, flatFilename);
+                    const filePath = safeJoin(baseStoragePath, flatFilename);
 
                     // Write file using Bun.write for optimal performance
                     if (typeof Bun !== 'undefined' && Bun.write) {
@@ -394,6 +400,12 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                         return { success: false, error: 'Missing required parameters' };
                     }
 
+                    // identifier is used to build the on-disk chunk directory; reject traversal.
+                    if (!isSafePathSegment(identifier)) {
+                        set.status = 400;
+                        return { success: false, error: 'Invalid identifier' };
+                    }
+
                     const uploadKey = `${projectId}:${identifier}`;
 
                     // Initialize upload tracking SYNCHRONOUSLY to prevent race condition
@@ -401,7 +413,8 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     // BEFORE any async operation, otherwise multiple chunks enter the if block
                     // and overwrite each other's uploadedChunks Set
                     if (!chunkUploads.has(uploadKey)) {
-                        const chunkDir = path.join(process.cwd(), 'data', 'chunks', projectId, identifier);
+                        const chunksRoot = path.join(process.cwd(), 'data', 'chunks');
+                        const chunkDir = safeJoin(chunksRoot, projectId, identifier);
                         chunkUploads.set(uploadKey, {
                             projectId,
                             filename,
@@ -468,6 +481,12 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     const componentId = data.componentId;
                     const clientId = data.clientId || uuidv4();
 
+                    // clientId becomes the on-disk filename; reject traversal/separators.
+                    if (!isSafePathSegment(clientId)) {
+                        set.status = 400;
+                        return { success: false, error: 'Invalid clientId' };
+                    }
+
                     const uploadKey = `${projectId}:${identifier}`;
                     const upload = chunkUploads.get(uploadKey);
 
@@ -497,9 +516,9 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     await fs.ensureDir(storagePath);
 
                     // Use clientId as filename with original extension
-                    const ext = path.extname(upload.filename).toLowerCase();
+                    const ext = sanitizeFileExtension(upload.filename);
                     const flatFilename = `${clientId}${ext}`;
-                    const finalPath = path.join(storagePath, flatFilename);
+                    const finalPath = safeJoin(storagePath, flatFilename);
 
                     // Write combined file with parallel chunk reads
                     const writeStream = fs.createWriteStream(finalPath);
@@ -867,6 +886,14 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                         metadata = data.metadata;
                     }
 
+                    // Each clientId becomes an on-disk filename; reject traversal/separators up front.
+                    for (const meta of metadata) {
+                        if (!isSafePathSegment(meta?.clientId)) {
+                            set.status = 400;
+                            return { success: false, error: 'Invalid clientId in metadata' };
+                        }
+                    }
+
                     // Get files from FormData
                     let files: (Blob | Buffer)[] = [];
                     if (data.files) {
@@ -902,9 +929,9 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                         // folderPath is only stored in database for UI/export, not on disk
 
                         // Use clientId as filename with original extension
-                        const ext = path.extname(filename).toLowerCase();
+                        const ext = sanitizeFileExtension(filename);
                         const flatFilename = `${fileMeta.clientId}${ext}`;
-                        const filePath = path.join(baseStoragePath, flatFilename);
+                        const filePath = safeJoin(baseStoragePath, flatFilename);
 
                         return {
                             clientId: fileMeta.clientId,
@@ -1074,6 +1101,11 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     }
 
                     const clientId = request.headers.get('x-client-id') || uuidv4();
+                    // clientId becomes the on-disk filename; reject traversal/separators.
+                    if (!isSafePathSegment(clientId)) {
+                        set.status = 400;
+                        return { success: false, error: 'Invalid clientId' };
+                    }
                     const filename = request.headers.get('x-filename') || 'uploaded_file';
                     const priority = parseInt(request.headers.get('x-priority') || '0', 10);
                     const contentType = request.headers.get('content-type') || 'application/octet-stream';
@@ -1099,9 +1131,9 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     await fs.ensureDir(baseStoragePath);
 
                     // Use clientId as filename with original extension
-                    const ext = path.extname(filename).toLowerCase();
+                    const ext = sanitizeFileExtension(filename);
                     const flatFilename = `${clientId}${ext}`;
-                    const filePath = path.join(baseStoragePath, flatFilename);
+                    const filePath = safeJoin(baseStoragePath, flatFilename);
 
                     // Stream body directly to disk
                     const body = request.body;

--- a/src/routes/export.spec.ts
+++ b/src/routes/export.spec.ts
@@ -400,6 +400,81 @@ describe('Export Routes', () => {
         });
     });
 
+    describe('path-traversal hardening (C2)', () => {
+        // A traversal odeSessionId (decoded from %2F by Elysia) must be rejected
+        // with 400 BEFORE any filesystem path is built, so an attacker cannot
+        // coerce getOdeSessionTempDir/getOdeSessionDistDir into escaping FILES_DIR.
+        const traversalId = '..%2F..%2F..%2Ftmp%2Fpwned';
+
+        it('should reject a traversal odeSessionId with 400 (GET) and write nothing outside FILES_DIR', async () => {
+            const pwnedPath = path.join(testDir, '..', '..', '..', 'tmp', 'pwned.zip');
+
+            const res = await handle(new Request(`http://localhost/api/export/${traversalId}/html5/download`));
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.success).toBe(false);
+            expect(body.error).toContain('Invalid session id');
+            // No ZIP was written outside the intended base directory.
+            expect(await fs.pathExists(pwnedPath)).toBe(false);
+        });
+
+        it('should reject a traversal odeSessionId with 400 (POST) and write nothing outside FILES_DIR', async () => {
+            const pwnedPath = path.join(testDir, '..', '..', '..', 'tmp', 'pwned.zip');
+
+            const res = await handle(
+                new Request(`http://localhost/api/export/${traversalId}/html5/download`, {
+                    method: 'POST',
+                    body: JSON.stringify({}),
+                    headers: { 'Content-Type': 'application/json' },
+                }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.success).toBe(false);
+            expect(body.error).toContain('Invalid session id');
+            expect(await fs.pathExists(pwnedPath)).toBe(false);
+        });
+
+        it('should reject a plain (non-encoded) traversal odeSessionId with 400', async () => {
+            const res = await handle(new Request('http://localhost/api/export/..%2Fevil/html5/download'));
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.success).toBe(false);
+            expect(body.error).toContain('Invalid session id');
+        });
+
+        it('should still accept a legitimate timestamp session id', async () => {
+            // testSessionId ('20250116testexport') is a normal id and must keep working.
+            const res = await handle(new Request(`http://localhost/api/export/${testSessionId}/html5/download`));
+
+            expect(res.status).toBe(200);
+        });
+
+        it('should still accept a legitimate UUID session id', async () => {
+            const uuidSessionId = 'aaa54536-d8d2-4a7b-bf6d-c809321ccc2a';
+            mockSessions.set(uuidSessionId, {
+                id: uuidSessionId,
+                sessionId: uuidSessionId,
+                fileName: 'uuid-project.elp',
+                userId: OWNER_USER_ID,
+                structure: mockParsedStructure,
+            });
+            await fs.ensureDir(path.join(testDir, 'tmp', uuidSessionId));
+            await fs.ensureDir(path.join(testDir, 'dist', uuidSessionId));
+            await fs.writeFile(
+                path.join(testDir, 'tmp', uuidSessionId, 'content.xml'),
+                '<?xml version="1.0"?><ode></ode>',
+            );
+
+            const res = await handle(new Request(`http://localhost/api/export/${uuidSessionId}/html5/download`));
+
+            expect(res.status).toBe(200);
+        });
+    });
+
     describe('export type validation', () => {
         // Types fully implemented in unified export system
         // All export types are now implemented in the unified export system

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -12,6 +12,7 @@ import * as fsExtra from 'fs-extra';
 import * as pathModule from 'path';
 
 import { buildContentDisposition } from '../shared/http/headers';
+import { isSafePathSegment } from '../utils/safe-path';
 import { getSession as getSessionDefault, type ProjectSession } from '../services/session-manager';
 import type { ExportOptionsRequest, YjsExportStructure } from './types/request-payloads';
 import { withJwtAuth } from '../utils/route-auth';
@@ -664,6 +665,13 @@ export function createExportRoutes(deps: ExportDependencies = {}): Elysia {
             .get('/:odeSessionId/:exportType/download', async ({ params, set, jwtPayload }) => {
                 const { odeSessionId, exportType } = params;
 
+                // Reject path-traversal session ids before any filesystem path is built.
+                // Real ids are UUIDs or YYYYMMDDHHmmss + alphanumerics, all of which pass.
+                if (!isSafePathSegment(odeSessionId, { allowDots: true })) {
+                    set.status = 400;
+                    return { success: false, error: 'Invalid session id' };
+                }
+
                 const session = getSession(odeSessionId);
                 const authz = authorizeExport(session, jwtPayload);
                 if (!authz.ok) {
@@ -722,6 +730,13 @@ export function createExportRoutes(deps: ExportDependencies = {}): Elysia {
             .post('/:odeSessionId/:exportType/download', async ({ params, body, set, jwtPayload }) => {
                 const { odeSessionId, exportType } = params;
                 const options = body as ExportOptionsRequest;
+
+                // Reject path-traversal session ids before any filesystem path is built.
+                // Real ids are UUIDs or YYYYMMDDHHmmss + alphanumerics, all of which pass.
+                if (!isSafePathSegment(odeSessionId, { allowDots: true })) {
+                    set.status = 400;
+                    return { success: false, error: 'Invalid session id' };
+                }
 
                 let session = getSession(odeSessionId);
                 const authz = authorizeExport(session, jwtPayload);

--- a/src/routes/games.spec.ts
+++ b/src/routes/games.spec.ts
@@ -4,22 +4,60 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { Elysia } from 'elysia';
+import { SignJWT } from 'jose';
 import * as Y from 'yjs';
 import { gamesRoutes, configureGamesRoutes, resetGamesRoutesDeps, extractIdevicesFromYjsDoc } from './games';
 import { createSessionManager, type SessionManager } from '../services/session-manager';
 
+// Must match the fallback in getJwtSecret() (API_JWT_SECRET || JWT_SECRET ||
+// 'dev_secret_change_me') so signed tokens verify inside withJwtAuth().
+const TEST_JWT_SECRET = 'dev_secret_change_me';
+const OWNER_USER_ID = 42;
+
+/**
+ * Sign a JWT the way the real auth flow does, so withJwtAuth().verify() accepts
+ * it. Returned token is passed via the `auth` cookie (same-origin path used by
+ * the editor/preview) so the access guard sees an authenticated caller.
+ */
+async function signTestToken(sub: number, roles: string[] = ['ROLE_USER']): Promise<string> {
+    const secret = new TextEncoder().encode(TEST_JWT_SECRET);
+    return new SignJWT({ sub, email: `u${sub}@test.local`, roles })
+        .setProtectedHeader({ alg: 'HS256' })
+        .setIssuedAt()
+        .setExpirationTime('1h')
+        .sign(secret);
+}
+
+/** Build an authenticated GET Request carrying the signed token in the auth cookie. */
+function authedRequest(url: string, token: string): Request {
+    return new Request(url, { headers: { Cookie: `auth=${token}` } });
+}
+
 describe('Games Routes', () => {
     let app: any;
     let mockSessionManager: SessionManager;
+    let ownerToken: string;
 
-    beforeEach(() => {
+    beforeEach(async () => {
+        // Deterministic secret for signing/verification in this spec.
+        process.env.JWT_SECRET = TEST_JWT_SECRET;
+
         // Create isolated session manager for tests
         mockSessionManager = createSessionManager();
 
-        // Configure DI to use mock session manager
+        // Configure DI to use mock session manager. Access-control mocks grant
+        // access by default (project found + owner) so the data-extraction
+        // tests below exercise the response shape, not the auth gate. Tests
+        // that assert 401/403/404 override these via configureGamesRoutes().
         configureGamesRoutes({
             getSession: mockSessionManager.getSession,
+            findProjectByUuid: async () =>
+                ({ id: 1, uuid: 'any', user_id: OWNER_USER_ID, share_type: 'private' }) as never,
+            findProjectById: async () => undefined as never,
+            checkProjectAccess: async () => ({ hasAccess: true }) as never,
         });
+
+        ownerToken = await signTestToken(OWNER_USER_ID);
 
         // Create test app with routes
         app = new Elysia().use(gamesRoutes);
@@ -33,7 +71,9 @@ describe('Games Routes', () => {
 
     describe('GET /api/games/:odeSessionId/idevices', () => {
         it('should return empty array for non-existent session', async () => {
-            const response = await app.handle(new Request('http://localhost/api/games/non-existent-session/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/non-existent-session/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -46,7 +86,9 @@ describe('Games Routes', () => {
                 sessionId: 'test-session-1',
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-session-1/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-session-1/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -99,7 +141,9 @@ describe('Games Routes', () => {
                 },
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-session-2/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-session-2/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -145,7 +189,9 @@ describe('Games Routes', () => {
                 },
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-session-3/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-session-3/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -174,7 +220,9 @@ describe('Games Routes', () => {
                 },
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-session-4/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-session-4/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -222,7 +270,9 @@ describe('Games Routes', () => {
                 },
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-session-5/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-session-5/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -258,7 +308,9 @@ describe('Games Routes', () => {
                 },
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/my-session-id/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/my-session-id/idevices', ownerToken),
+            );
 
             const data = await response.json();
             expect(data.data[0].ode_session_id).toBe('my-session-id');
@@ -284,7 +336,9 @@ describe('Games Routes', () => {
                 },
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-session-single/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-session-single/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -326,7 +380,7 @@ describe('Games Routes', () => {
             });
 
             const response = await app.handle(
-                new Request('http://localhost/api/games/test-blocks-no-components/idevices'),
+                authedRequest('http://localhost/api/games/test-blocks-no-components/idevices', ownerToken),
             );
 
             expect(response.status).toBe(200);
@@ -364,7 +418,7 @@ describe('Games Routes', () => {
             });
 
             const response = await app.handle(
-                new Request('http://localhost/api/games/test-simplified-blocks-no-components/idevices'),
+                authedRequest('http://localhost/api/games/test-simplified-blocks-no-components/idevices', ownerToken),
             );
 
             expect(response.status).toBe(200);
@@ -407,7 +461,9 @@ describe('Games Routes', () => {
                 },
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-parent-id/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-parent-id/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -458,7 +514,7 @@ describe('Games Routes', () => {
             });
 
             const response = await app.handle(
-                new Request('http://localhost/api/games/test-isactive-undefined/idevices'),
+                authedRequest('http://localhost/api/games/test-isactive-undefined/idevices', ownerToken),
             );
 
             expect(response.status).toBe(200);
@@ -506,7 +562,9 @@ describe('Games Routes', () => {
                 },
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-json-object/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-json-object/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -552,7 +610,9 @@ describe('Games Routes', () => {
                 },
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-html-object/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-html-object/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -649,7 +709,9 @@ describe('Games Routes', () => {
 
             // For a session without structure, it should try Yjs fallback
             // (which won't find anything in test environment)
-            const response = await app.handle(new Request('http://localhost/api/games/yjs-test-session/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/yjs-test-session/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -679,7 +741,9 @@ describe('Games Routes', () => {
                 },
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-prefer-structure/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-prefer-structure/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -697,7 +761,9 @@ describe('Games Routes', () => {
                 // No structure property
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/test-empty-structure/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/test-empty-structure/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -709,7 +775,7 @@ describe('Games Routes', () => {
             // For non-existent session, Yjs fallback is tried but finds nothing
             // Should still return success:true with empty data
             const response = await app.handle(
-                new Request('http://localhost/api/games/completely-unknown-session/idevices'),
+                authedRequest('http://localhost/api/games/completely-unknown-session/idevices', ownerToken),
             );
 
             expect(response.status).toBe(200);
@@ -757,14 +823,18 @@ describe('Games Routes', () => {
             configureGamesRoutes({
                 getSession: () => undefined, // No session in memory
                 getDb: () => mockDb as never,
-                findProjectByUuid: async () => ({ id: 123, uuid: 'db-session-id' }) as never,
+                findProjectByUuid: async () =>
+                    ({ id: 123, uuid: 'db-session-id', user_id: OWNER_USER_ID, share_type: 'private' }) as never,
+                checkProjectAccess: async () => ({ hasAccess: true }) as never,
                 findSnapshotByProjectId: async () =>
                     ({
                         snapshot_data: Buffer.from(snapshotData),
                     }) as never,
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/db-session-id/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/db-session-id/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -778,31 +848,41 @@ describe('Games Routes', () => {
             expect(data.data[0].htmlViewer).toBe('<div>Quiz content</div>');
         });
 
-        it('should return empty array when project not found in database', async () => {
+        it('should return 404 when project not found (access gate runs first)', async () => {
+            // Access control resolves the project before any data loading, so an
+            // unknown UUID is rejected with 404 rather than leaking a 200/empty
+            // response that would let callers probe which UUIDs exist.
             configureGamesRoutes({
                 getSession: () => undefined,
                 getDb: () => ({}) as never,
                 findProjectByUuid: async () => undefined, // Project not found
+                checkProjectAccess: async () => ({ hasAccess: true }) as never,
                 findSnapshotByProjectId: async () => undefined,
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/unknown-project-id/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/unknown-project-id/idevices', ownerToken),
+            );
 
-            expect(response.status).toBe(200);
+            expect(response.status).toBe(404);
             const data = await response.json();
-            expect(data.success).toBe(true);
-            expect(data.data).toEqual([]);
+            expect(data.success).toBe(false);
+            expect(data.error).toBe('Project not found');
         });
 
         it('should return empty array when snapshot has no data', async () => {
             configureGamesRoutes({
                 getSession: () => undefined,
                 getDb: () => ({}) as never,
-                findProjectByUuid: async () => ({ id: 123, uuid: 'project-id' }) as never,
+                findProjectByUuid: async () =>
+                    ({ id: 123, uuid: 'project-id', user_id: OWNER_USER_ID, share_type: 'private' }) as never,
+                checkProjectAccess: async () => ({ hasAccess: true }) as never,
                 findSnapshotByProjectId: async () => undefined, // No snapshot
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/project-id/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/project-id/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
@@ -810,40 +890,183 @@ describe('Games Routes', () => {
             expect(data.data).toEqual([]);
         });
 
-        it('should handle database errors gracefully', async () => {
-            configureGamesRoutes({
-                getSession: () => undefined,
-                getDb: () => {
-                    throw new Error('Database connection failed');
-                },
-                findProjectByUuid: async () => undefined,
-                findSnapshotByProjectId: async () => undefined,
-            });
-
-            const response = await app.handle(new Request('http://localhost/api/games/error-session/idevices'));
-
-            expect(response.status).toBe(200);
-            const data = await response.json();
-            expect(data.success).toBe(true);
-            expect(data.data).toEqual([]);
-        });
-
-        it('should handle findProjectByUuid errors gracefully', async () => {
+        it('should handle snapshot-loading errors gracefully after access is granted', async () => {
+            // Access control passes, then the data-loading fallback hits a DB
+            // error while reading the Yjs snapshot. That error is swallowed and
+            // an empty data set is returned (graceful degradation), since the
+            // caller is already authorized.
             configureGamesRoutes({
                 getSession: () => undefined,
                 getDb: () => ({}) as never,
-                findProjectByUuid: async () => {
-                    throw new Error('Query failed');
+                findProjectByUuid: async () =>
+                    ({ id: 123, uuid: 'error-session', user_id: OWNER_USER_ID, share_type: 'private' }) as never,
+                checkProjectAccess: async () => ({ hasAccess: true }) as never,
+                findSnapshotByProjectId: async () => {
+                    throw new Error('Snapshot query failed');
                 },
-                findSnapshotByProjectId: async () => undefined,
             });
 
-            const response = await app.handle(new Request('http://localhost/api/games/query-error-session/idevices'));
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/error-session/idevices', ownerToken),
+            );
 
             expect(response.status).toBe(200);
             const data = await response.json();
             expect(data.success).toBe(true);
             expect(data.data).toEqual([]);
+        });
+    });
+
+    /**
+     * Access control (security gate)
+     *
+     * The endpoint returns the full flattened iDevice structure of a project,
+     * including each component's rendered HTML. It must require authentication
+     * and per-project access so that knowing a project UUID is not enough to
+     * read its contents.
+     */
+    describe('Access control', () => {
+        const NON_OWNER_USER_ID = 99;
+
+        it('should reject unauthenticated requests with 401', async () => {
+            // No auth cookie / Authorization header at all.
+            const response = await app.handle(new Request('http://localhost/api/games/some-project-uuid/idevices'));
+
+            expect(response.status).toBe(401);
+            const data = await response.json();
+            expect(data.success).toBe(false);
+        });
+
+        it('should reject an invalid/expired token with 401', async () => {
+            const response = await app.handle(
+                new Request('http://localhost/api/games/some-project-uuid/idevices', {
+                    headers: { Cookie: 'auth=not-a-valid-jwt' },
+                }),
+            );
+
+            expect(response.status).toBe(401);
+            const data = await response.json();
+            expect(data.success).toBe(false);
+        });
+
+        it('should return 403 for an authenticated non-owner on a PRIVATE project', async () => {
+            // Private project owned by someone else; checkProjectAccess denies.
+            configureGamesRoutes({
+                getSession: () => undefined,
+                getDb: () => ({}) as never,
+                findProjectByUuid: async () =>
+                    ({ id: 7, uuid: 'private-uuid', user_id: OWNER_USER_ID, share_type: 'private' }) as never,
+                checkProjectAccess: async () => ({ hasAccess: false, reason: 'No access to project' }) as never,
+            });
+
+            const nonOwnerToken = await signTestToken(NON_OWNER_USER_ID);
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/private-uuid/idevices', nonOwnerToken),
+            );
+
+            expect(response.status).toBe(403);
+            const data = await response.json();
+            expect(data.success).toBe(false);
+            expect(data.error).toBe('Access denied');
+        });
+
+        it('should return 200 for the owner of a private project', async () => {
+            mockSessionManager.createSession({
+                sessionId: 'owner-uuid',
+                structure: {
+                    pages: [
+                        {
+                            id: 'page-1',
+                            title: 'Owner Page',
+                            blocks: [{ id: 'block-1', name: 'Block', components: [{ id: 'comp-1', type: 'text' }] }],
+                        },
+                    ],
+                },
+            });
+            configureGamesRoutes({
+                getSession: mockSessionManager.getSession,
+                getDb: () => ({}) as never,
+                findProjectByUuid: async () =>
+                    ({ id: 7, uuid: 'owner-uuid', user_id: OWNER_USER_ID, share_type: 'private' }) as never,
+                checkProjectAccess: async () => ({ hasAccess: true }) as never,
+            });
+
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/owner-uuid/idevices', ownerToken),
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.success).toBe(true);
+            expect(data.data.length).toBe(1);
+            expect(data.data[0].odePageId).toBe('page-1');
+        });
+
+        it('should return 200 for an authenticated non-owner on a PUBLIC project', async () => {
+            // Public project: checkProjectAccess grants access to any
+            // authenticated user (same semantics as the Yjs WebSocket).
+            mockSessionManager.createSession({
+                sessionId: 'public-uuid',
+                structure: {
+                    pages: [
+                        {
+                            id: 'pub-page',
+                            title: 'Public Page',
+                            blocks: [{ id: 'b1', name: 'B', components: [{ id: 'c1', type: 'text' }] }],
+                        },
+                    ],
+                },
+            });
+            configureGamesRoutes({
+                getSession: mockSessionManager.getSession,
+                getDb: () => ({}) as never,
+                findProjectByUuid: async () =>
+                    ({ id: 8, uuid: 'public-uuid', user_id: OWNER_USER_ID, share_type: 'public' }) as never,
+                checkProjectAccess: async () => ({ hasAccess: true }) as never,
+            });
+
+            const nonOwnerToken = await signTestToken(NON_OWNER_USER_ID);
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/public-uuid/idevices', nonOwnerToken),
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.success).toBe(true);
+            expect(data.data.length).toBe(1);
+            expect(data.data[0].odePageId).toBe('pub-page');
+        });
+
+        it('should grant access to an admin without checking project access', async () => {
+            let checkCalled = false;
+            mockSessionManager.createSession({
+                sessionId: 'admin-uuid',
+                structure: {
+                    pages: [{ id: 'a-page', title: 'Admin Page', blocks: [] }],
+                },
+            });
+            configureGamesRoutes({
+                getSession: mockSessionManager.getSession,
+                getDb: () => ({}) as never,
+                findProjectByUuid: async () =>
+                    ({ id: 9, uuid: 'admin-uuid', user_id: OWNER_USER_ID, share_type: 'private' }) as never,
+                checkProjectAccess: async () => {
+                    checkCalled = true;
+                    return { hasAccess: false } as never;
+                },
+            });
+
+            const adminToken = await signTestToken(NON_OWNER_USER_ID, ['ROLE_USER', 'ROLE_ADMIN']);
+            const response = await app.handle(
+                authedRequest('http://localhost/api/games/admin-uuid/idevices', adminToken),
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.success).toBe(true);
+            expect(data.data.length).toBe(1);
+            // Admin short-circuits before checkProjectAccess.
+            expect(checkCalled).toBe(false);
         });
     });
 });

--- a/src/routes/games.ts
+++ b/src/routes/games.ts
@@ -10,9 +10,12 @@ import * as Y from 'yjs';
 import { getSession as getSessionDefault, type ProjectSession } from '../services/session-manager';
 import { getDb as getDbDefault } from '../db/client';
 import {
+    checkProjectAccess as checkProjectAccessDefault,
+    findProjectById as findProjectByIdDefault,
     findProjectByUuid as findProjectByUuidDefault,
     findSnapshotByProjectId as findSnapshotByProjectIdDefault,
 } from '../db/queries';
+import { enforceProjectAccess, withJwtAuth } from '../utils/route-auth';
 
 // ============================================================================
 // DEPENDENCY INJECTION
@@ -22,6 +25,8 @@ export interface GamesRoutesDeps {
     getSession: (sessionId: string) => ProjectSession | undefined;
     getDb: typeof getDbDefault;
     findProjectByUuid: typeof findProjectByUuidDefault;
+    findProjectById: typeof findProjectByIdDefault;
+    checkProjectAccess: typeof checkProjectAccessDefault;
     findSnapshotByProjectId: typeof findSnapshotByProjectIdDefault;
 }
 
@@ -29,6 +34,8 @@ const defaultDeps: GamesRoutesDeps = {
     getSession: getSessionDefault,
     getDb: getDbDefault,
     findProjectByUuid: findProjectByUuidDefault,
+    findProjectById: findProjectByIdDefault,
+    checkProjectAccess: checkProjectAccessDefault,
     findSnapshotByProjectId: findSnapshotByProjectIdDefault,
 };
 
@@ -521,6 +528,12 @@ function extractIdevicesFromYjsDoc(sessionId: string, ydoc: Y.Doc): SessionIdevi
  * Games routes - endpoints used by game iDevices
  */
 export const gamesRoutes = new Elysia({ prefix: '/api/games' })
+    // Auth: this endpoint returns the full flattened iDevice structure of a
+    // project (including each component's rendered HTML), so it must never be
+    // reachable anonymously. `withJwtAuth` derives a nullable `jwtPayload`
+    // (from the `Authorization` header or the same-origin `auth` cookie) and
+    // bubbles it to the route via `.as('scoped')`.
+    .use(withJwtAuth())
     /**
      * GET /api/games/:odeSessionId/idevices
      *
@@ -531,8 +544,27 @@ export const gamesRoutes = new Elysia({ prefix: '/api/games' })
      */
     .get(
         '/:odeSessionId/idevices',
-        async ({ params }) => {
+        async ({ params, jwtPayload, set }) => {
             const { odeSessionId } = params;
+
+            // Access control: `:odeSessionId` is a project UUID. Require an
+            // authenticated caller with access to the project (owner /
+            // collaborator / admin, or any authenticated user on public
+            // projects — same semantics as the Yjs WebSocket via
+            // checkProjectAccess). Returns 401/403/404 otherwise.
+            const access = await enforceProjectAccess(jwtPayload, odeSessionId, {
+                db: deps.getDb(),
+                queries: {
+                    findProjectByUuid: deps.findProjectByUuid,
+                    findProjectById: deps.findProjectById,
+                    checkProjectAccess: deps.checkProjectAccess,
+                },
+                acceptNumericId: false,
+            });
+            if ('status' in access) {
+                set.status = access.status;
+                return { success: false, error: access.message };
+            }
 
             // Get session from memory (using DI)
             const session = deps.getSession(odeSessionId);

--- a/src/routes/idevices.spec.ts
+++ b/src/routes/idevices.spec.ts
@@ -961,4 +961,140 @@ describe('iDevices Routes', () => {
             }
         });
     });
+
+    // Targeted coverage for the rewriteCSSUrls() helper: a CSS file containing
+    // relative url(...) references must have those rewritten to the download
+    // API endpoint, while absolute/data/http URLs are left untouched.
+    describe('CSS URL rewriting (relative references)', () => {
+        it('should rewrite relative url() references to the download API endpoint', async () => {
+            // beforeafter.css references images via relative `url(quextIEHit.png)`,
+            // which exercises every branch of the url() replace callback.
+            const resourcePath = 'perm/idevices/base/beforeafter/edition/beforeafter.css';
+            const res = await handle(
+                new Request(`http://localhost/api/idevices/download-file-resources?resource=${resourcePath}`),
+            );
+
+            expect(res.status).toBe(200);
+            expect(res.headers.get('Content-Type')).toBe('text/css');
+
+            const content = await res.text();
+            // Relative references must be rewritten to the API endpoint with the
+            // resolved (normalized) resource path encoded as a query parameter.
+            expect(content).toContain('/api/idevices/download-file-resources?resource=');
+            expect(content).toContain(encodeURIComponent('perm/idevices/base/beforeafter/edition/quextIEHit.png'));
+            // The raw relative reference must no longer be present.
+            expect(content).not.toContain('url(quextIEHit.png)');
+        });
+    });
+
+    // Targeted coverage for the duplicate-filename de-duplication loop in both
+    // upload handlers: uploading the same filename to the same session twice
+    // must produce distinct stored filenames (file, file_1, ...).
+    describe('duplicate filename handling', () => {
+        it('should generate a unique filename when a base64 upload collides', async () => {
+            // Unique session per run so the target directory is always empty,
+            // making the first/second collision deterministic regardless of any
+            // files left behind by previous test runs.
+            const session = `dup-base64-session-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+            const payload = (n: number) => ({
+                odeIdeviceId: 'dup-base64-idevice',
+                file: 'data:text/plain;base64,SGVsbG8=',
+                filename: 'collide.txt',
+                odeSessionId: session,
+                tag: n,
+            });
+
+            const first = await handle(
+                new Request('http://localhost/api/idevices/upload/file/resources', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload(1)),
+                }),
+            );
+            const second = await handle(
+                new Request('http://localhost/api/idevices/upload/file/resources', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload(2)),
+                }),
+            );
+
+            expect(first.status).toBe(200);
+            expect(second.status).toBe(200);
+            const firstBody = await first.json();
+            const secondBody = await second.json();
+
+            expect(firstBody.savedFilename).toBe('collide.txt');
+            // Collision must be resolved by suffixing a counter before the extension.
+            expect(secondBody.savedFilename).not.toBe(firstBody.savedFilename);
+            expect(secondBody.savedFilename).toBe('collide_1.txt');
+        });
+
+        it('should generate a unique filename when a large upload collides', async () => {
+            // Unique session per run for deterministic collision ordering.
+            const session = `dup-large-session-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+            const payload = (n: number) => ({
+                odeIdeviceId: 'dup-large-idevice',
+                file: `content-${n}`,
+                filename: 'big.txt',
+                odeSessionId: session,
+            });
+
+            const first = await handle(
+                new Request('http://localhost/api/idevices/upload/large/file/resources', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload(1)),
+                }),
+            );
+            const second = await handle(
+                new Request('http://localhost/api/idevices/upload/large/file/resources', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload(2)),
+                }),
+            );
+
+            expect(first.status).toBe(200);
+            expect(second.status).toBe(200);
+            const firstBody = await first.json();
+            const secondBody = await second.json();
+
+            expect(firstBody.savedFilename).toBe('big.txt');
+            expect(secondBody.savedFilename).toBe('big_1.txt');
+        });
+    });
+
+    // Targeted coverage for the GET /:ideviceId handler success path returning a
+    // fully-parsed config, plus regression coverage that a normal slug still
+    // resolves after the path-traversal hardening.
+    describe('GET /api/idevices/installed/:ideviceId (resolved config)', () => {
+        it('should return the full parsed config for a real base iDevice', async () => {
+            const res = await handle(new Request('http://localhost/api/idevices/installed/text'));
+
+            // `text` is a core base iDevice and must always resolve.
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body.id).toBe('text');
+            // The single-iDevice handler returns the raw config (no `name` alias),
+            // including the file arrays and template fields produced by parsing.
+            expect(Array.isArray(body.editionJs)).toBe(true);
+            expect(Array.isArray(body.exportJs)).toBe(true);
+            expect(typeof body.exportObject).toBe('string');
+            expect(body.exportObject.startsWith('$')).toBe(true);
+            // url points at the parsed base directory for this iDevice.
+            expect(body.url).toContain('idevices/base/text');
+        });
+
+        it('should return 404 for a syntactically valid but unknown slug', async () => {
+            const res = await handle(
+                new Request('http://localhost/api/idevices/installed/totally_unknown-idevice-2025'),
+            );
+
+            expect(res.status).toBe(404);
+            const body = await res.json();
+            expect(body.error).toBe('Not Found');
+            expect(body.id).toBeUndefined();
+        });
+    });
 });

--- a/src/routes/idevices.spec.ts
+++ b/src/routes/idevices.spec.ts
@@ -208,6 +208,61 @@ describe('iDevices Routes', () => {
             expect(body.apiVersion).toBeDefined();
             expect(body.componentType).toBeDefined();
         });
+
+        // Regression tests for path traversal (security audit H14): the raw
+        // `:ideviceId` param was joined into a filesystem path and the matching
+        // `config.xml` was read/parsed with no validation, enabling
+        // unauthenticated arbitrary file read and a filesystem existence oracle.
+        // A traversal id must be rejected with the route's normal 404 shape and
+        // must never read a file outside the iDevices base directories.
+        describe('path traversal hardening (H14)', () => {
+            // Encoded so the segment survives the HTTP layer; Elysia decodes
+            // `%2F` back into `/` before the handler sees the param.
+            const traversalIds = [
+                '..%2F..%2F..%2Fetc%2Fpasswd',
+                '..%2F..%2Fconfig%2Fsecrets',
+                '%2Fetc%2Fpasswd',
+                '..%2F..%2F..%2F..%2Fpackage',
+            ];
+
+            for (const encodedId of traversalIds) {
+                it(`should reject traversal id "${encodedId}" with 404 and read nothing outside base`, async () => {
+                    const res = await handle(new Request(`http://localhost/api/idevices/installed/${encodedId}`));
+
+                    expect(res.status).toBe(404);
+                    const body = await res.json();
+                    expect(body.error).toBe('Not Found');
+                    // Must not leak a parsed config from an out-of-base file.
+                    expect(body.id).toBeUndefined();
+                });
+            }
+
+            it('should reject ids containing a dot segment with 404', async () => {
+                // iDevice ids are slugs (alphanumeric/_/-); dotted values are not
+                // valid ids and must not reach the filesystem.
+                const res = await handle(new Request('http://localhost/api/idevices/installed/some.thing'));
+
+                expect(res.status).toBe(404);
+                const body = await res.json();
+                expect(body.error).toBe('Not Found');
+            });
+
+            it('should still resolve a normal slug id after hardening', async () => {
+                const listRes = await handle(new Request('http://localhost/api/idevices/installed'));
+                const listBody = await listRes.json();
+                // Prefer a hyphenated id to confirm hyphens still pass validation.
+                const hyphenated = listBody.idevices.find((i: any) => i.id.includes('-'))?.id;
+                const ideviceId = hyphenated || listBody.idevices[0]?.id;
+
+                if (!ideviceId) return;
+
+                const res = await handle(new Request(`http://localhost/api/idevices/installed/${ideviceId}`));
+
+                expect(res.status).toBe(200);
+                const body = await res.json();
+                expect(body.id).toBe(ideviceId);
+            });
+        });
     });
 
     describe('GET /api/idevices/download-file-resources', () => {

--- a/src/routes/idevices.ts
+++ b/src/routes/idevices.ts
@@ -12,6 +12,7 @@ import { getBasePath } from '../utils/basepath.util';
 import type { IdeviceFileUploadRequest } from './types/request-payloads';
 import { withJwtAuth } from '../utils/route-auth';
 import { requireAuth } from '../utils/guards';
+import { isSafePathSegment, safeJoin, UnsafePathError } from '../utils/safe-path';
 
 /**
  * Response data for file upload
@@ -292,14 +293,34 @@ export const idevicesRoutes = new Elysia({ name: 'idevices-routes' })
     .get('/api/idevices/installed/:ideviceId', ({ params, set }) => {
         const { ideviceId } = params;
 
-        // Check user iDevices first
-        let configPath = path.join(IDEVICES_USERS_PATH, ideviceId, 'config.xml');
-        let basePath = path.join(IDEVICES_USERS_PATH, ideviceId);
+        // Security: iDevice ids are slugs (alphanumeric, `_`, `-`). Reject any
+        // value that could traverse outside the iDevices directories (e.g.
+        // `../../etc/passwd` or URL-encoded separators) before it reaches a
+        // filesystem sink. See src/utils/safe-path.ts.
+        if (!isSafePathSegment(ideviceId)) {
+            set.status = 404;
+            return { error: 'Not Found', message: `iDevice ${ideviceId} not found` };
+        }
+
+        // Check user iDevices first. safeJoin re-validates each segment and
+        // asserts the resolved path stays within the base directory.
+        let basePath: string;
+        let configPath: string;
+        try {
+            basePath = safeJoin(IDEVICES_USERS_PATH, ideviceId);
+            configPath = safeJoin(IDEVICES_USERS_PATH, ideviceId, 'config.xml');
+        } catch (err) {
+            if (err instanceof UnsafePathError) {
+                set.status = 404;
+                return { error: 'Not Found', message: `iDevice ${ideviceId} not found` };
+            }
+            throw err;
+        }
 
         if (!fs.existsSync(configPath)) {
             // Fall back to base iDevices
-            configPath = path.join(IDEVICES_BASE_PATH, ideviceId, 'config.xml');
-            basePath = path.join(IDEVICES_BASE_PATH, ideviceId);
+            basePath = safeJoin(IDEVICES_BASE_PATH, ideviceId);
+            configPath = safeJoin(IDEVICES_BASE_PATH, ideviceId, 'config.xml');
         }
 
         if (!fs.existsSync(configPath)) {

--- a/src/routes/pages.spec.ts
+++ b/src/routes/pages.spec.ts
@@ -190,9 +190,13 @@ describe('Pages Routes', () => {
         mockPreferences = new Map();
         sessionIdCounter = 0;
 
-        // Reset env
+        // Reset env. The canonical resolver (auth.ts:getJwtSecret) prefers
+        // API_JWT_SECRET over JWT_SECRET, and the test env sets API_JWT_SECRET via
+        // .env, so we override API_JWT_SECRET to the value tokens are signed with.
+        // Routes are created below in this hook, after the env is set.
         process.env.APP_ONLINE_MODE = '1';
         process.env.APP_AUTH_METHODS = 'form,guest';
+        process.env.API_JWT_SECRET = 'test-secret-for-testing-only';
         process.env.JWT_SECRET = 'test-secret-for-testing-only';
 
         // Create test user

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -5,6 +5,7 @@
  * Uses Dependency Injection pattern for testability
  */
 import { Elysia } from 'elysia';
+import { getJwtSecret } from './auth';
 import { cookie } from '@elysiajs/cookie';
 import { jwt } from '@elysiajs/jwt';
 import { randomBytes } from 'crypto';
@@ -227,11 +228,6 @@ const defaultDependencies: PagesDependencies = {
 };
 
 const isOfflineMode = () => String(process.env.APP_ONLINE_MODE ?? '1') === '0';
-
-// Get JWT secret
-const getJwtSecret = () => {
-    return process.env.JWT_SECRET || process.env.APP_SECRET || 'elysia-dev-secret-change-me';
-};
 
 // ============================================================================
 // Factory Function

--- a/src/routes/platform-integration.spec.ts
+++ b/src/routes/platform-integration.spec.ts
@@ -34,6 +34,10 @@ describe('Platform Integration Routes', () => {
         delete process.env.PROVIDER_IDS;
         delete process.env.PROVIDER_TOKENS;
         delete process.env.PROVIDER_URLS;
+        // Provider URL validation now fails closed (bug M3): an empty allow-list rejects every
+        // returnurl. Configure a default allow-list matching the happy-path return URLs so the
+        // many 200-expecting tests keep passing. Tests that set their own PROVIDER_URLS override this.
+        process.env.PROVIDER_URLS = 'https://moodle.example.com';
     });
 
     afterEach(() => {
@@ -641,6 +645,23 @@ describe('Platform Integration Routes', () => {
             const token = await createValidToken({
                 returnurl: 'https://other-moodle.com/mod/exescorm/view.php',
             });
+
+            const response = await app.handle(
+                new Request('http://localhost/api/platform/integration/openPlatformElp', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ jwt_token: token }),
+                }),
+            );
+
+            expect(response.status).toBe(401);
+        });
+
+        it('should reject valid-signature tokens when PROVIDER_URLS is unset (fail closed)', async () => {
+            // Bug M3: an empty allow-list must reject every return URL instead of allowing all.
+            delete process.env.PROVIDER_URLS;
+
+            const token = await createValidToken();
 
             const response = await app.handle(
                 new Request('http://localhost/api/platform/integration/openPlatformElp', {

--- a/src/routes/platform-integration.spec.ts
+++ b/src/routes/platform-integration.spec.ts
@@ -4,7 +4,11 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { SignJWT } from 'jose';
-import { platformIntegrationRoutes } from './platform-integration';
+import {
+    platformIntegrationRoutes,
+    configurePlatformIntegrationRoutes,
+    resetPlatformIntegrationRoutesDependencies,
+} from './platform-integration';
 import {
     configure as configureService,
     resetDependencies as resetServiceDependencies,
@@ -37,6 +41,8 @@ describe('Platform Integration Routes', () => {
         globalThis.fetch = originalFetch;
         // Reset service dependencies
         resetServiceDependencies();
+        // Reset route-level dependencies (ownership check lookup)
+        resetPlatformIntegrationRoutesDependencies();
         // Restore original environment variables
         Object.keys(originalEnv).forEach(key => {
             if (originalEnv[key] !== undefined) {
@@ -303,6 +309,12 @@ describe('Platform Integration Routes', () => {
         it('should return error when project not found', async () => {
             const token = await createValidToken();
 
+            // Route ownership lookup also sees no project, so the gate defers
+            // to the service, which returns the canonical "Project not found".
+            configurePlatformIntegrationRoutes({
+                findProjectByUuid: async () => undefined,
+            });
+
             // Configure service with mock that returns null for project
             configureService({
                 findProjectByUuid: async () => null,
@@ -328,6 +340,12 @@ describe('Platform Integration Routes', () => {
         it('should return success when upload succeeds', async () => {
             const token = await createValidToken();
             const mockSnapshot = createMockSnapshot();
+
+            // Project is already linked to the same platform module (cmid '456'
+            // from the JWT), so the ownership gate must allow the export.
+            configurePlatformIntegrationRoutes({
+                findProjectByUuid: async () => makeProjectRow({ uuid: 'test-uuid', platform_id: '456' }),
+            });
 
             // Configure service with mocks
             configureService({
@@ -372,6 +390,11 @@ describe('Platform Integration Routes', () => {
             const token = await createValidToken();
             const mockSnapshot = createMockSnapshot();
 
+            // Unlinked project (platform_id null) passes the ownership gate.
+            configurePlatformIntegrationRoutes({
+                findProjectByUuid: async () => makeProjectRow({ uuid: 'test-uuid', platform_id: null }),
+            });
+
             configureService({
                 findProjectByUuid: async () => ({
                     id: 1,
@@ -408,6 +431,11 @@ describe('Platform Integration Routes', () => {
             const token = await createValidToken();
             const mockSnapshot = createMockSnapshot();
 
+            // Unlinked project (platform_id null) passes the ownership gate.
+            configurePlatformIntegrationRoutes({
+                findProjectByUuid: async () => makeProjectRow({ uuid: 'test-uuid', platform_id: null }),
+            });
+
             configureService({
                 findProjectByUuid: async () => ({
                     id: 1,
@@ -439,6 +467,113 @@ describe('Platform Integration Routes', () => {
 
             const data = await response.json();
             expect(data.responseMessage).toContain('Connection refused');
+        });
+
+        it('returns 403 and performs no export/post-back when the project belongs to another platform module (IDOR)', async () => {
+            // Attacker holds a valid JWT for their own course module (cmid '456'),
+            // but supplies a victim's projectUuid that is bound to a different
+            // module (cmid '999'). The ownership gate must deny the request.
+            const token = await createValidToken({ cmid: '456' });
+
+            configurePlatformIntegrationRoutes({
+                findProjectByUuid: async () => makeProjectRow({ uuid: 'victim-uuid', platform_id: '999' }),
+            });
+
+            // Spy on the export/post-back dependencies. None of them must run.
+            let snapshotLookupCalled = false;
+            let updateCalled = false;
+            configureService({
+                findProjectByUuid: async () => {
+                    throw new Error('service.findProjectByUuid must not run when access is denied');
+                },
+                findSnapshotByProjectId: async () => {
+                    snapshotLookupCalled = true;
+                    return createMockSnapshot();
+                },
+                updateProjectByUuid: async () => {
+                    updateCalled = true;
+                    return undefined;
+                },
+            });
+
+            // Network must never be touched (no ZIP shipped to the platform).
+            let fetchCalled = false;
+            globalThis.fetch = async () => {
+                fetchCalled = true;
+                return new Response(JSON.stringify({ status: '0' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            };
+
+            const response = await app.handle(
+                new Request('http://localhost/api/platform/integration/set_platform_new_ode', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        projectUuid: 'victim-uuid',
+                        jwt_token: token,
+                    }),
+                }),
+            );
+
+            expect(response.status).toBe(403);
+
+            const data = await response.json();
+            expect(data.responseMessage).toContain('Forbidden');
+
+            // Critically: no export was generated and nothing was posted back.
+            expect(fetchCalled).toBe(false);
+            expect(snapshotLookupCalled).toBe(false);
+            expect(updateCalled).toBe(false);
+        });
+
+        it('proceeds when the project is bound to the same platform module as the JWT', async () => {
+            // Project's platform_id matches the JWT cmid: legitimate re-save.
+            const token = await createValidToken({ cmid: '456' });
+            const mockSnapshot = createMockSnapshot();
+
+            let snapshotLookupCalled = false;
+            configurePlatformIntegrationRoutes({
+                findProjectByUuid: async () => makeProjectRow({ uuid: 'owned-uuid', platform_id: '456' }),
+            });
+            configureService({
+                findProjectByUuid: async () => ({
+                    id: 1,
+                    uuid: 'owned-uuid',
+                    title: 'Test Project',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                }),
+                findSnapshotByProjectId: async () => {
+                    snapshotLookupCalled = true;
+                    return mockSnapshot;
+                },
+                updateProjectByUuid: async () => undefined,
+            });
+
+            globalThis.fetch = async () =>
+                new Response(JSON.stringify({ status: '0' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+
+            const response = await app.handle(
+                new Request('http://localhost/api/platform/integration/set_platform_new_ode', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        projectUuid: 'owned-uuid',
+                        jwt_token: token,
+                    }),
+                }),
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.responseMessage).toBe('OK');
+            // The gate let the export proceed.
+            expect(snapshotLookupCalled).toBe(true);
         });
     });
 
@@ -690,6 +825,32 @@ describe('Platform Integration Routes', () => {
         });
     });
 });
+
+/**
+ * Build a minimal project row for the route-level ownership lookup.
+ *
+ * Only the fields read by the ownership gate matter; the rest are filled with
+ * representative defaults so the object satisfies the Project shape.
+ */
+function makeProjectRow(overrides: { uuid?: string; platform_id?: string | null } = {}) {
+    return {
+        id: 1,
+        uuid: overrides.uuid ?? 'test-uuid',
+        title: 'Test Project',
+        description: null,
+        owner_id: 1,
+        status: 'active',
+        visibility: 'private',
+        language: 'en',
+        author: null,
+        license: null,
+        last_accessed_at: null,
+        saved_once: 1,
+        platform_id: overrides.platform_id ?? null,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+    };
+}
 
 /**
  * Create a minimal mock Yjs document with the required structure

--- a/src/routes/platform-integration.ts
+++ b/src/routes/platform-integration.ts
@@ -6,9 +6,89 @@
  * bidirectional file transfer (download from platform, upload to platform).
  */
 import { Elysia, t } from 'elysia';
+import type { Kysely } from 'kysely';
 import { getBasePath } from '../utils/basepath.util';
 import { decodePlatformJWT, getPlatformIntegrationParams } from '../utils/platform-jwt';
 import { platformPetitionGet, platformPetitionSet, platformPetitionSetForward } from '../services/platform-integration';
+import { db as defaultDb } from '../db/client';
+import { findProjectByUuid as findProjectByUuidDefault } from '../db/queries';
+import type { Database } from '../db/types';
+
+/**
+ * Route-level dependencies for platform integration.
+ *
+ * The export/post-back handlers must enforce that a client-supplied
+ * `projectUuid` actually belongs to the platform identity carried by the
+ * validated JWT before exporting and shipping its contents back to the
+ * platform. That ownership check needs to read the project row (in
+ * particular `platform_id`), so the lookup is exposed here for dependency
+ * injection in tests instead of mutating the service-level dependencies.
+ */
+export interface PlatformIntegrationRouteDependencies {
+    db: Kysely<Database>;
+    findProjectByUuid: typeof findProjectByUuidDefault;
+}
+
+const defaultRouteDeps: PlatformIntegrationRouteDependencies = {
+    db: defaultDb,
+    findProjectByUuid: findProjectByUuidDefault,
+};
+
+let routeDeps = defaultRouteDeps;
+
+/**
+ * Configure route-level dependencies (for testing).
+ */
+export function configurePlatformIntegrationRoutes(newDeps: Partial<PlatformIntegrationRouteDependencies>): void {
+    routeDeps = { ...defaultRouteDeps, ...newDeps };
+}
+
+/**
+ * Reset route-level dependencies to their defaults.
+ */
+export function resetPlatformIntegrationRoutesDependencies(): void {
+    routeDeps = defaultRouteDeps;
+}
+
+/**
+ * Authorize that a project may be exported to / posted back to the platform
+ * identified by a validated JWT.
+ *
+ * Ownership invariant (prevents IDOR — bug M2): a project that is already
+ * bound to a platform course module (`projects.platform_id` is set — this is
+ * written by `platformPetitionSet` / `platformPetitionSetForward` on a
+ * successful upload, and stores the JWT's `cmid`) may only be exported when
+ * its stored `platform_id` matches the `cmid` in the validated JWT. Without
+ * this check, a legitimate-but-malicious platform user holding a valid JWT
+ * for their own course module could substitute a victim's `projectUuid` and
+ * exfiltrate its full contents via the platform post-back.
+ *
+ * A project whose `platform_id` is still `null` is being saved back to a
+ * platform for the first time (the link is established on success), so it is
+ * allowed to proceed. A non-existent project is NOT treated as a denial here:
+ * the lookup is left to the service so the existing "Project not found"
+ * response shape is preserved.
+ *
+ * @returns `true` if the export may proceed, `false` if it must be denied.
+ */
+async function isProjectAuthorizedForPlatform(projectUuid: string, jwtCmid: string): Promise<boolean> {
+    const project = await routeDeps.findProjectByUuid(routeDeps.db, projectUuid);
+
+    // Not found here is not an authorization failure: defer to the service,
+    // which returns the canonical "Project not found" response shape.
+    if (!project) {
+        return true;
+    }
+
+    // Unlinked projects (first save back to the platform) are allowed; the
+    // linkage is created on success.
+    if (project.platform_id == null) {
+        return true;
+    }
+
+    // Linked projects may only be exported to the platform module they belong to.
+    return project.platform_id === jwtCmid;
+}
 
 /**
  * Platform integration routes
@@ -160,6 +240,17 @@ export const platformIntegrationRoutes = new Elysia({ name: 'platform-integratio
                 set.status = 401;
                 return {
                     responseMessage: 'Invalid token or unauthorized provider',
+                };
+            }
+
+            // Ownership gate (IDOR — bug M2): a valid JWT only authorizes the
+            // platform module it was issued for. Refuse to export and post
+            // back a project that is bound to a different platform module.
+            const authorized = await isProjectAuthorizedForPlatform(projectUuid, params.cmid);
+            if (!authorized) {
+                set.status = 403;
+                return {
+                    responseMessage: 'Forbidden: project does not belong to this platform identity',
                 };
             }
 

--- a/src/routes/project.spec.ts
+++ b/src/routes/project.spec.ts
@@ -22,6 +22,26 @@ import type { Theme } from '../db/types';
 
 const testDir = path.join(process.cwd(), 'test', 'temp', 'project-test');
 
+/**
+ * Sign a JWT for the given user id using the same secret the routes verify
+ * (process.env.JWT_SECRET = 'test-secret-for-testing-only', set in beforeEach).
+ * Module-level so every describe block can authenticate requests.
+ */
+async function createAuthToken(userId: number = 1): Promise<string> {
+    const jwt = await import('@elysiajs/jwt');
+    const jwtInstance = jwt.jwt({
+        name: 'jwt',
+        secret: 'test-secret-for-testing-only',
+    });
+    const tempApp = new Elysia().use(jwtInstance);
+    return tempApp.decorator.jwt.sign({
+        sub: userId,
+        email: mockUsers.get(userId)?.email || 'test@test.com',
+        roles: ['ROLE_USER'],
+        isGuest: false,
+    });
+}
+
 // Mock data - shared state for tests
 let mockUsers: Map<number, any>;
 let mockProjects: Map<number, any>;
@@ -509,7 +529,12 @@ describe('Project Routes', () => {
             mockProjects.set(1, project);
             mockProjectsByUuid.set('test-project-uuid', project);
 
-            const res = await app.handle(new Request('http://localhost/api/projects/1/sharing'));
+            const token = await createAuthToken(1);
+            const res = await app.handle(
+                new Request('http://localhost/api/projects/1/sharing', {
+                    headers: { Cookie: `auth=${token}` },
+                }),
+            );
 
             expect(res.status).toBe(200);
             const body = await res.json();
@@ -532,13 +557,110 @@ describe('Project Routes', () => {
             mockProjects.set(1, project);
             mockProjectsByUuid.set('test-project-uuid', project);
 
-            const res = await app.handle(new Request('http://localhost/api/projects/uuid/test-project-uuid/sharing'));
+            const token = await createAuthToken(1);
+            const res = await app.handle(
+                new Request('http://localhost/api/projects/uuid/test-project-uuid/sharing', {
+                    headers: { Cookie: `auth=${token}` },
+                }),
+            );
 
             expect(res.status).toBe(200);
             const body = await res.json();
             expect(body.responseMessage).toBe('OK');
             expect(body.project.uuid).toBe('test-project-uuid');
             expect(body.project.visibility).toBe('private');
+        });
+
+        it('should return 401 for sharing info by project ID without auth', async () => {
+            const project = {
+                id: 1,
+                uuid: 'test-project-uuid',
+                owner_id: 1,
+                title: 'Test Project',
+                visibility: 'private',
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            };
+            mockProjects.set(1, project);
+            mockProjectsByUuid.set('test-project-uuid', project);
+
+            const res = await app.handle(new Request('http://localhost/api/projects/1/sharing'));
+
+            expect(res.status).toBe(401);
+            const body = await res.json();
+            expect(body.responseMessage).toBe('UNAUTHORIZED');
+        });
+
+        it('should return 403 for sharing info by project ID for non-owner on private project', async () => {
+            const project = {
+                id: 1,
+                uuid: 'test-project-uuid',
+                owner_id: 1,
+                title: 'Test Project',
+                visibility: 'private',
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            };
+            mockProjects.set(1, project);
+            mockProjectsByUuid.set('test-project-uuid', project);
+
+            // User 3 is neither owner nor collaborator
+            const token = await createAuthToken(3);
+            const res = await app.handle(
+                new Request('http://localhost/api/projects/1/sharing', {
+                    headers: { Cookie: `auth=${token}` },
+                }),
+            );
+
+            expect(res.status).toBe(403);
+            const body = await res.json();
+            expect(body.responseMessage).toBe('FORBIDDEN');
+        });
+
+        it('should return 401 for sharing info by UUID without auth on existing private project', async () => {
+            const project = {
+                id: 1,
+                uuid: 'test-project-uuid',
+                owner_id: 1,
+                title: 'Test Project',
+                visibility: 'private',
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            };
+            mockProjects.set(1, project);
+            mockProjectsByUuid.set('test-project-uuid', project);
+
+            const res = await app.handle(new Request('http://localhost/api/projects/uuid/test-project-uuid/sharing'));
+
+            expect(res.status).toBe(401);
+            const body = await res.json();
+            expect(body.responseMessage).toBe('UNAUTHORIZED');
+        });
+
+        it('should return 403 for sharing info by UUID for non-owner on existing private project', async () => {
+            const project = {
+                id: 1,
+                uuid: 'test-project-uuid',
+                owner_id: 1,
+                title: 'Test Project',
+                visibility: 'private',
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            };
+            mockProjects.set(1, project);
+            mockProjectsByUuid.set('test-project-uuid', project);
+
+            // User 3 is neither owner nor collaborator
+            const token = await createAuthToken(3);
+            const res = await app.handle(
+                new Request('http://localhost/api/projects/uuid/test-project-uuid/sharing', {
+                    headers: { Cookie: `auth=${token}` },
+                }),
+            );
+
+            expect(res.status).toBe(403);
+            const body = await res.json();
+            expect(body.responseMessage).toBe('FORBIDDEN');
         });
     });
 
@@ -1341,10 +1463,12 @@ describe('Project Routes', () => {
 
         it('should duplicate project', async () => {
             createTestProject(900, 'uuid-900', 1);
+            const token = await createAuthToken(1);
 
             const res = await app.handle(
                 new Request('http://localhost/api/projects/uuid/uuid-900/duplicate', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                 }),
             );
 
@@ -1355,10 +1479,39 @@ describe('Project Routes', () => {
             expect(body.project.title).toContain('copy');
         });
 
+        it('should return 401 when duplicating without auth', async () => {
+            createTestProject(910, 'uuid-910', 1);
+
+            const res = await app.handle(
+                new Request('http://localhost/api/projects/uuid/uuid-910/duplicate', {
+                    method: 'POST',
+                }),
+            );
+
+            expect(res.status).toBe(401);
+        });
+
+        it('should return 403 when non-owner duplicates a private project', async () => {
+            createTestProject(911, 'uuid-911', 1); // owner is user 1, visibility private
+            const token = await createAuthToken(3); // user 3 has no access
+
+            const res = await app.handle(
+                new Request('http://localhost/api/projects/uuid/uuid-911/duplicate', {
+                    method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
+                }),
+            );
+
+            expect(res.status).toBe(403);
+        });
+
         it('should return 404 for non-existent project', async () => {
+            const token = await createAuthToken(1);
+
             const res = await app.handle(
                 new Request('http://localhost/api/projects/uuid/non-existent/duplicate', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                 }),
             );
 
@@ -1386,9 +1539,11 @@ describe('Project Routes', () => {
                 updated_at: new Date().toISOString(),
             });
 
+            const token = await createAuthToken(1);
             const res = await app.handle(
                 new Request('http://localhost/api/projects/uuid/uuid-901-with-snapshot/duplicate', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                 }),
             );
 
@@ -1432,9 +1587,11 @@ describe('Project Routes', () => {
                 },
             ]);
 
+            const token = await createAuthToken(1);
             const res = await app.handle(
                 new Request('http://localhost/api/projects/uuid/uuid-902-with-assets/duplicate', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                 }),
             );
 
@@ -1454,10 +1611,12 @@ describe('Project Routes', () => {
 
         it('should handle project with no assets during duplication', async () => {
             createTestProject(903, 'uuid-903-no-assets', 1);
+            const token = await createAuthToken(1);
 
             const res = await app.handle(
                 new Request('http://localhost/api/projects/uuid/uuid-903-no-assets/duplicate', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                 }),
             );
 
@@ -1489,9 +1648,11 @@ describe('Project Routes', () => {
                 },
             ]);
 
+            const token = await createAuthToken(1);
             const res = await app.handle(
                 new Request('http://localhost/api/projects/uuid/uuid-904-asset-no-clientid/duplicate', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                 }),
             );
 
@@ -1562,9 +1723,11 @@ describe('Project Routes', () => {
                 updated_at: new Date().toISOString(),
             });
 
+            const token = await createAuthToken(1);
             const res = await app.handle(
                 new Request('http://localhost/api/projects/uuid/uuid-905-yjs-assets/duplicate', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                 }),
             );
 
@@ -1626,9 +1789,11 @@ describe('Project Routes', () => {
                 })),
             );
 
+            const token = await createAuthToken(1);
             const res = await app.handle(
                 new Request('http://localhost/api/projects/uuid/uuid-906-multi-assets/duplicate', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                 }),
             );
 
@@ -2915,7 +3080,12 @@ describe('Project Routes', () => {
             mockCollaborators.set(1501, new Set([2]));
             mockUsers.set(2, { id: 2, email: 'collab@test.com', roles: 'ROLE_USER' });
 
-            const res = await app.handle(new Request('http://localhost/api/projects/uuid/uuid-sharing-test/sharing'));
+            const token = await createAuthToken(1);
+            const res = await app.handle(
+                new Request('http://localhost/api/projects/uuid/uuid-sharing-test/sharing', {
+                    headers: { Cookie: `auth=${token}` },
+                }),
+            );
 
             expect(res.status).toBe(200);
             const body = await res.json();
@@ -3079,9 +3249,11 @@ describe('Project Routes', () => {
             mockProjectsByUuid.set('no-snapshot-project', project);
 
             // Use main app which doesn't have snapshot functions mocked
+            const token = await createAuthToken(1);
             const res = await app.handle(
                 new Request('http://localhost/api/projects/uuid/no-snapshot-project/duplicate', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                 }),
             );
 
@@ -3156,8 +3328,12 @@ describe('Project Routes', () => {
                 }),
             );
 
-            // Should still return 200 for public project even without valid auth
-            expect(res.status).toBe(200);
+            // An invalid token yields no authenticated user. Numeric sharing now
+            // requires authentication (M1), so an unverifiable token is rejected
+            // gracefully with 401 rather than leaking PII for the public project.
+            expect(res.status).toBe(401);
+            const body = await res.json();
+            expect(body.responseMessage).toBe('UNAUTHORIZED');
         });
     });
 
@@ -4010,7 +4186,12 @@ describe('Project Routes', () => {
         });
 
         it('should return 404 for non-existent project in sharing', async () => {
-            const res = await app.handle(new Request('http://localhost/api/projects/99999/sharing'));
+            const token = await createAuthToken(1);
+            const res = await app.handle(
+                new Request('http://localhost/api/projects/99999/sharing', {
+                    headers: { Cookie: `auth=${token}` },
+                }),
+            );
 
             expect(res.status).toBe(404);
             const body = await res.json();

--- a/src/routes/project.spec.ts
+++ b/src/routes/project.spec.ts
@@ -1960,11 +1960,30 @@ describe('Project Routes', () => {
     });
 
     describe('Link Validation (brokenlinks)', () => {
-        it('should return no broken links for empty content', async () => {
+        // Brokenlinks endpoints now require authentication (bug H1); supply a token to each request.
+        let authToken: string;
+
+        beforeEach(async () => {
+            authToken = await createAuthToken(1);
+        });
+
+        it('should require authentication', async () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ idevices: [] }),
+                }),
+            );
+
+            expect(res.status).toBe(401);
+        });
+
+        it('should return no broken links for empty content', async () => {
+            const res = await app.handle(
+                new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({ idevices: [] }),
                 }),
             );
@@ -1979,7 +1998,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -2003,7 +2022,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -2025,7 +2044,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -2043,11 +2062,30 @@ describe('Project Routes', () => {
     });
 
     describe('Link Extraction (brokenlinks/extract)', () => {
-        it('should extract links without validating', async () => {
+        // Extract endpoint now requires authentication (bug H1); supply a token to each request.
+        let authToken: string;
+
+        beforeEach(async () => {
+            authToken = await createAuthToken(1);
+        });
+
+        it('should require authentication', async () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks/extract', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ idevices: [{ html: '<a href="https://google.com">Google</a>' }] }),
+                }),
+            );
+
+            expect(res.status).toBe(401);
+        });
+
+        it('should extract links without validating', async () => {
+            const res = await app.handle(
+                new Request('http://localhost/api/ode-management/odes/session/brokenlinks/extract', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -2080,7 +2118,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks/extract', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [{ html: '<p>No links here</p>' }],
                     }),
@@ -2097,7 +2135,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks/extract', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -2117,11 +2155,30 @@ describe('Project Routes', () => {
     });
 
     describe('Link Validation Stream (brokenlinks/validate-stream)', () => {
-        it('should stream validation results for exe-node links', async () => {
+        // Validate-stream endpoint now requires authentication (bug H1); supply a token to each request.
+        let authToken: string;
+
+        beforeEach(async () => {
+            authToken = await createAuthToken(1);
+        });
+
+        it('should require authentication', async () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks/validate-stream', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ links: [] }),
+                }),
+            );
+
+            expect(res.status).toBe(401);
+        });
+
+        it('should stream validation results for exe-node links', async () => {
+            const res = await app.handle(
+                new Request('http://localhost/api/ode-management/odes/session/brokenlinks/validate-stream', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         links: [
                             {
@@ -2158,7 +2215,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks/validate-stream', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         links: [
                             {
@@ -2187,7 +2244,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks/validate-stream', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({ links: [] }),
                 }),
             );
@@ -3946,6 +4003,13 @@ describe('Project Routes', () => {
     });
 
     describe('Link Validation Extended Coverage', () => {
+        // Brokenlinks endpoint now requires authentication (bug H1); supply a token to each request.
+        let authToken: string;
+
+        beforeEach(async () => {
+            authToken = await createAuthToken(1);
+        });
+
         it('should return null (valid) for existing internal files/', async () => {
             // Create test file that exists
             const filesDir = path.join(testDir, 'files');
@@ -3955,7 +4019,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -3976,7 +4040,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -3997,7 +4061,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -4019,7 +4083,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -4039,7 +4103,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -4059,7 +4123,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -4080,7 +4144,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -5246,13 +5310,20 @@ describe('Project Routes', () => {
     });
 
     describe('Link Validation Special Cases', () => {
+        // Brokenlinks endpoint now requires authentication (bug H1); supply a token to each request.
+        let authToken: string;
+
+        beforeEach(async () => {
+            authToken = await createAuthToken(1);
+        });
+
         it('should handle file path check throwing error', async () => {
             // This tests the catch block in file path validation (line 1769-1770)
             // We can't easily make fs.pathExists throw, but the test structure is here
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {
@@ -5273,7 +5344,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/ode-management/odes/session/brokenlinks', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${authToken}` },
                     body: JSON.stringify({
                         idevices: [
                             {

--- a/src/routes/project.spec.ts
+++ b/src/routes/project.spec.ts
@@ -342,6 +342,7 @@ function createMockDependencies(): ProjectDependencies {
 describe('Project Routes', () => {
     let app: Elysia;
     let mockDeps: ProjectDependencies;
+    const originalEnv = { ...process.env };
 
     beforeEach(async () => {
         // Reset mock data
@@ -373,7 +374,11 @@ describe('Project Routes', () => {
             roles: '["ROLE_USER"]',
         });
 
-        // Set JWT secret
+        // Set JWT secret. The canonical resolver (auth.ts:getJwtSecret) prefers
+        // API_JWT_SECRET over JWT_SECRET, and the test env sets API_JWT_SECRET via
+        // .env, so we override API_JWT_SECRET to the value tokens are signed with.
+        // Routes are created below in this hook, after the env is set.
+        process.env.API_JWT_SECRET = 'test-secret-for-testing-only';
         process.env.JWT_SECRET = 'test-secret-for-testing-only';
 
         // Create mock dependencies
@@ -387,6 +392,9 @@ describe('Project Routes', () => {
     });
 
     afterEach(async () => {
+        // Restore env so the test secret never leaks into other suites in the
+        // same Bun process.
+        process.env = { ...originalEnv };
         if (await fs.pathExists(testDir)) {
             await fs.remove(testDir);
         }

--- a/src/routes/project.ts
+++ b/src/routes/project.ts
@@ -36,7 +36,10 @@ import { jwt } from '@elysiajs/jwt';
 import { createGravatarUrl as createGravatarUrlDefault } from '../utils/gravatar.util';
 import {
     extractLinksFromIdevices,
+    validateLink,
     validateLinksStream,
+    toBrokenLinkInfo,
+    type BrokenLinkInfo,
     type ExtractedLink,
     type IdeviceContent,
 } from '../services/link-validator';
@@ -1823,177 +1826,28 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
             // =====================================================
 
             // POST /api/ode-management/odes/session/brokenlinks - Validate links in content
-            .post('/api/ode-management/odes/session/brokenlinks', async ({ body }) => {
+            .post('/api/ode-management/odes/session/brokenlinks', async ({ body, set, currentUser }) => {
+                // Server-side link validation issues outbound requests; require
+                // authentication so it cannot be abused unauthenticated (H1). The
+                // shared validateLink() is SSRF-hardened (rejects internal hosts).
+                if (!currentUser) {
+                    set.status = 401;
+                    return { responseMessage: 'UNAUTHORIZED', detail: 'Authentication required' };
+                }
+
                 const data = body as UsedFilesRequest;
-                const idevices = data.idevices || [];
+                const idevices = (data.idevices || []) as IdeviceContent[];
                 const filesDir = getFilesDir();
 
-                interface BrokenLinkInfo {
-                    brokenLinks: string;
-                    nTimesBrokenLinks: number | null;
-                    brokenLinksError: string | null;
-                    pageNamesBrokenLinks: string;
-                    blockNamesBrokenLinks: string;
-                    typeComponentSyncBrokenLinks: string;
-                    orderComponentSyncBrokenLinks: string;
-                }
-
-                interface ExtractedLink {
-                    url: string;
-                    count: number;
-                }
-
-                // Extract links from HTML
-                const extractLinks = (html: string): ExtractedLink[] => {
-                    if (!html) return [];
-                    const regex = /(href|src)="([^"]*)"/gi;
-                    const links: ExtractedLink[] = [];
-                    let match: RegExpExecArray | null;
-                    while ((match = regex.exec(html)) !== null) {
-                        links.push({ url: match[2], count: 1 });
-                    }
-                    return links;
-                };
-
-                // Clean and count links
-                const cleanAndCountLinks = (links: ExtractedLink[]): ExtractedLink[] => {
-                    const urlCounts = new Map<string, number>();
-                    for (const link of links) {
-                        const cleanUrl = link.url.replace(/"/g, '');
-                        urlCounts.set(cleanUrl, (urlCounts.get(cleanUrl) || 0) + 1);
-                    }
-                    return Array.from(urlCounts.entries()).map(([url, count]) => ({ url, count }));
-                };
-
-                // Remove invalid links
-                const removeInvalidLinks = (links: ExtractedLink[]): ExtractedLink[] => {
-                    return links.filter(link => {
-                        if (!link.url || link.url.trim() === '') return false;
-                        if (link.url.startsWith('#')) return false;
-                        if (link.url.startsWith('javascript:')) return false;
-                        if (link.url.startsWith('data:')) return false;
-                        return true;
-                    });
-                };
-
-                // Deduplicate links
-                const deduplicateLinks = (links: ExtractedLink[]): ExtractedLink[] => {
-                    const uniqueLinks = new Map<string, ExtractedLink>();
-                    for (const link of links) {
-                        const existing = uniqueLinks.get(link.url);
-                        if (!existing || link.count > existing.count) {
-                            uniqueLinks.set(link.url, link);
-                        }
-                    }
-                    return Array.from(uniqueLinks.values());
-                };
-
-                // Validate a single link
-                const validateLink = async (url: string): Promise<string | null> => {
-                    // Internal page links (exe-node:) - consider valid
-                    if (url.startsWith('exe-node:')) {
-                        return null;
-                    }
-
-                    // Internal file links (files/...)
-                    if (url.startsWith('files/') || url.startsWith('files\\')) {
-                        try {
-                            const relativePath = url.substring(6);
-                            const fullPath = path.join(filesDir, relativePath);
-                            if (await fs.pathExists(fullPath)) {
-                                return null;
-                            }
-                            return '404';
-                        } catch {
-                            return '500';
-                        }
-                    }
-
-                    // Skip relative URLs that aren't files/
-                    if (!url.startsWith('http://') && !url.startsWith('https://') && !url.startsWith('//')) {
-                        return null;
-                    }
-
-                    // External link validation
-                    try {
-                        let normalizedUrl = url;
-                        if (url.startsWith('//')) {
-                            normalizedUrl = 'https:' + url;
-                        }
-
-                        const controller = new AbortController();
-                        const timeoutId = setTimeout(() => controller.abort(), 10000);
-
-                        try {
-                            let response = await fetch(normalizedUrl, {
-                                method: 'HEAD',
-                                signal: controller.signal,
-                                redirect: 'follow',
-                                headers: {
-                                    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
-                                },
-                            });
-
-                            clearTimeout(timeoutId);
-
-                            // If HEAD returns 405, try GET
-                            if (response.status === 405) {
-                                const controller2 = new AbortController();
-                                const timeoutId2 = setTimeout(() => controller2.abort(), 10000);
-                                response = await fetch(normalizedUrl, {
-                                    method: 'GET',
-                                    signal: controller2.signal,
-                                    redirect: 'follow',
-                                    headers: {
-                                        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
-                                        Range: 'bytes=0-0',
-                                    },
-                                });
-                                clearTimeout(timeoutId2);
-                            }
-
-                            // 301 is not broken
-                            if (response.status === 301) return null;
-                            if (response.ok) return null;
-                            return String(response.status);
-                        } catch (fetchError: unknown) {
-                            clearTimeout(timeoutId);
-                            const err = fetchError as { name?: string; message?: string; cause?: { code?: string } };
-                            if (err.name === 'AbortError') return 'Timeout';
-                            const cause = err.cause;
-                            if (cause?.code === 'ENOTFOUND') return 'Could not resolve host';
-                            if (cause?.code === 'ECONNREFUSED') return 'Connection refused';
-                            return err.message || 'Network error';
-                        }
-                    } catch {
-                        return 'URL using bad/illegal format';
-                    }
-                };
-
+                // Single source of truth: reuse the shared link-validator service
+                // (extraction + SSRF-safe validation) instead of a duplicated copy.
+                const links = extractLinksFromIdevices(idevices);
                 const allBrokenLinks: BrokenLinkInfo[] = [];
 
-                for (const idevice of idevices) {
-                    if (!idevice.html) continue;
-
-                    let links = extractLinks(idevice.html);
-                    links = cleanAndCountLinks(links);
-                    links = removeInvalidLinks(links);
-                    links = deduplicateLinks(links);
-
-                    for (const link of links) {
-                        const validationError = await validateLink(link.url);
-
-                        if (validationError) {
-                            allBrokenLinks.push({
-                                brokenLinks: link.url,
-                                nTimesBrokenLinks: link.count,
-                                brokenLinksError: validationError,
-                                pageNamesBrokenLinks: idevice.pageName || '',
-                                blockNamesBrokenLinks: idevice.blockName || '',
-                                typeComponentSyncBrokenLinks: idevice.ideviceType || '',
-                                orderComponentSyncBrokenLinks: String(idevice.order ?? ''),
-                            });
-                        }
+                for (const link of links) {
+                    const validationError = await validateLink(link.url, { filesDir });
+                    if (validationError) {
+                        allBrokenLinks.push(toBrokenLinkInfo(link, validationError));
                     }
                 }
 
@@ -2022,7 +1876,12 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
             })
 
             // POST /api/ode-management/odes/session/brokenlinks/extract - Extract links without validating (fast)
-            .post('/api/ode-management/odes/session/brokenlinks/extract', async ({ body }) => {
+            .post('/api/ode-management/odes/session/brokenlinks/extract', async ({ body, set, currentUser }) => {
+                if (!currentUser) {
+                    set.status = 401;
+                    return { responseMessage: 'UNAUTHORIZED', detail: 'Authentication required' };
+                }
+
                 const data = body as UsedFilesRequest;
                 const idevices = (data.idevices || []) as IdeviceContent[];
 
@@ -2036,25 +1895,33 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
             })
 
             // POST /api/ode-management/odes/session/brokenlinks/validate-stream - Validate links via SSE
-            .post('/api/ode-management/odes/session/brokenlinks/validate-stream', async function* ({ body }) {
-                const data = body as { links: ExtractedLink[] };
-                const links = data.links || [];
-                const filesDir = getFilesDir();
+            .post(
+                '/api/ode-management/odes/session/brokenlinks/validate-stream',
+                async function* ({ body, set, currentUser }) {
+                    if (!currentUser) {
+                        set.status = 401;
+                        return;
+                    }
 
-                // Stream validation results as SSE events
-                for await (const result of validateLinksStream(links, { filesDir, batchSize: 5 })) {
+                    const data = body as { links: ExtractedLink[] };
+                    const links = data.links || [];
+                    const filesDir = getFilesDir();
+
+                    // Stream validation results as SSE events
+                    for await (const result of validateLinksStream(links, { filesDir, batchSize: 5 })) {
+                        yield {
+                            event: 'link-validated',
+                            data: JSON.stringify(result),
+                        };
+                    }
+
+                    // Signal completion
                     yield {
-                        event: 'link-validated',
-                        data: JSON.stringify(result),
+                        event: 'done',
+                        data: JSON.stringify({ complete: true, totalValidated: links.length }),
                     };
-                }
-
-                // Signal completion
-                yield {
-                    event: 'done',
-                    data: JSON.stringify({ complete: true, totalValidated: links.length }),
-                };
-            })
+                },
+            )
 
             // =====================================================
             // Utilities: Resources Report (usedfiles)

--- a/src/routes/project.ts
+++ b/src/routes/project.ts
@@ -5,6 +5,7 @@
  * Uses Dependency Injection pattern for testability
  */
 import { Elysia } from 'elysia';
+import { getJwtSecret } from './auth';
 import * as fsDefault from 'fs-extra';
 import * as pathDefault from 'path';
 
@@ -366,11 +367,6 @@ function serializeProjectSharing(
         updatedAt: project.updated_at,
     };
 }
-
-// Get JWT secret
-const getJwtSecret = () => {
-    return process.env.JWT_SECRET || process.env.APP_SECRET || 'elysia-dev-secret-change-me';
-};
 
 // ============================================================================
 // Factory Functions

--- a/src/routes/project.ts
+++ b/src/routes/project.ts
@@ -902,10 +902,24 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                     return { responseMessage: 'INVALID_ID', detail: 'Invalid project ID' };
                 }
 
+                // Sharing info exposes owner/collaborator emails (PII). Require
+                // authentication and project access; previously this endpoint was
+                // unauthenticated and enumerable by sequential numeric id (M1).
+                if (!currentUser) {
+                    set.status = 401;
+                    return { responseMessage: 'UNAUTHORIZED', detail: 'Authentication required' };
+                }
+
                 const project = await findProjectById(db, projectId);
                 if (!project) {
                     set.status = 404;
                     return { responseMessage: 'NOT_FOUND', detail: 'Project not found' };
+                }
+
+                const sharingAccess = await checkProjectAccess(db, project, currentUser.id);
+                if (!sharingAccess.hasAccess) {
+                    set.status = 403;
+                    return { responseMessage: 'FORBIDDEN', detail: 'Access denied' };
                 }
 
                 const owner = await findUserById(db, project.owner_id);
@@ -1181,16 +1195,17 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
             .get('/api/projects/uuid/:uuid/sharing', async ({ params, set, currentUser }) => {
                 const uuid = params.uuid;
 
+                // Sharing info exposes owner/collaborator emails (PII). Require
+                // authentication before resolving/creating or returning it (M1).
+                if (!currentUser) {
+                    set.status = 401;
+                    return { responseMessage: 'UNAUTHORIZED', detail: 'Authentication required' };
+                }
+
                 let project = await findProjectByUuid(db, uuid);
 
                 // If project doesn't exist in DB, create it with current user as owner
                 if (!project) {
-                    // Require authentication to create project
-                    if (!currentUser) {
-                        set.status = 401;
-                        return { responseMessage: 'UNAUTHORIZED', detail: 'Authentication required' };
-                    }
-
                     // Create the project in DB with current user as owner
                     project = await createProjectWithUuid(db, uuid, {
                         title: 'Untitled',
@@ -1200,6 +1215,13 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                     });
 
                     console.log(`[Project] Created project ${uuid} for user ${currentUser.id} via sharing endpoint`);
+                } else {
+                    // Existing project: caller must have access to see its sharing/PII.
+                    const sharingAccess = await checkProjectAccess(db, project, currentUser.id);
+                    if (!sharingAccess.hasAccess) {
+                        set.status = 403;
+                        return { responseMessage: 'FORBIDDEN', detail: 'Access denied' };
+                    }
                 }
 
                 const owner = await findUserById(db, project.owner_id);
@@ -1388,10 +1410,25 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
             .post('/api/projects/uuid/:uuid/duplicate', async ({ params, set, currentUser }) => {
                 const uuid = params.uuid;
 
+                // Require authentication and access to the SOURCE project before
+                // copying its content. Previously any caller (even unauthenticated)
+                // could clone an arbitrary private project into their own account
+                // and then read/export it (IDOR, C4).
+                if (!currentUser) {
+                    set.status = 401;
+                    return { error: 'Unauthorized', message: 'Authentication required' };
+                }
+
                 const project = await findProjectByUuid(db, uuid);
                 if (!project) {
                     set.status = 404;
                     return { error: 'Not Found', message: 'Project not found' };
+                }
+
+                const duplicateAccess = await checkProjectAccess(db, project, currentUser.id);
+                if (!duplicateAccess.hasAccess) {
+                    set.status = 403;
+                    return { error: 'Forbidden', message: 'Access denied' };
                 }
 
                 // Generate new UUID for the duplicate

--- a/src/routes/themes.spec.ts
+++ b/src/routes/themes.spec.ts
@@ -1245,4 +1245,138 @@ describe('Themes Routes', () => {
             expect(themeWithIcons.url).not.toContain('/exe//');
         });
     });
+
+    describe('path traversal protection (security audit C3 / H14)', () => {
+        // Theme ids/names are slugs ([a-z0-9_-]). Every endpoint that joins the
+        // route param onto a base directory must reject traversal segments BEFORE
+        // touching the filesystem, otherwise an attacker can escape the themes
+        // base (Elysia decodes `%2F` to a real separator) and read arbitrary
+        // files such as .env or the database.
+        //
+        // These are the dangerous forms that survive WHATWG URL parsing and
+        // actually reach the handler with separators intact (a bare `..`
+        // segment, by contrast, is collapsed by the URL parser before routing —
+        // see the dedicated test below).
+        const TRAVERSAL_NAMES = [
+            '..%2F..%2F..%2F..%2Fetc%2Fpasswd', // encoded slashes -> real separators
+            '..%2F..%2Fsecret',
+            '%2E%2E%2Fsecret', // fully-encoded ../secret
+            '%2Eetc', // encoded dot prefix; not a valid slug (would be an existence oracle)
+            'foo%2Fbar', // separator hidden inside an otherwise valid-looking name
+        ];
+
+        // Endpoints that take a theme name/id route param and build a path from it.
+        const ENDPOINTS = [
+            (name: string) => `http://localhost/api/themes/installed/${name}`,
+            (name: string) => `http://localhost/api/resources/theme/${name}/bundle`,
+            (name: string) => `http://localhost/api/themes/${name}/download`,
+        ];
+
+        /**
+         * Wraps the real fs with spies that record every absolute path the route
+         * touches, so a test can assert the handler never reached outside the base.
+         */
+        function spyFs(): {
+            touched: string[];
+        } {
+            const touched: string[] = [];
+            const record = (p: unknown): void => {
+                if (typeof p === 'string') {
+                    touched.push(p);
+                }
+            };
+            configure({
+                fs: {
+                    existsSync: (p: string) => {
+                        record(p);
+                        return fs.existsSync(p);
+                    },
+                    readFileSync: ((p: string, encoding?: BufferEncoding) => {
+                        record(p);
+                        return fs.readFileSync(p, encoding);
+                    }) as typeof fs.readFileSync,
+                    readdirSync: ((p: string, options?: { withFileTypes: boolean }) => {
+                        record(p);
+                        return fs.readdirSync(p, options);
+                    }) as typeof fs.readdirSync,
+                },
+            });
+            app = new Elysia().use(themesRoutes);
+            return { touched };
+        }
+
+        for (const makeUrl of ENDPOINTS) {
+            for (const name of TRAVERSAL_NAMES) {
+                it(`returns 404 and reads nothing outside the base for ${makeUrl('<name>')} = ${name}`, async () => {
+                    const { touched } = spyFs();
+
+                    const res = await app.handle(new Request(makeUrl(name)));
+
+                    expect(res.status).toBe(404);
+                    const body = await res.json();
+                    expect(body.error).toBe('Not Found');
+
+                    // Validation must short-circuit BEFORE any filesystem access.
+                    expect(touched).toHaveLength(0);
+
+                    resetDependencies();
+                });
+            }
+        }
+
+        it('never reaches the handler for a bare ".." segment (collapsed before routing)', async () => {
+            // A literal `..` in the URL path is normalized away by the WHATWG URL
+            // parser before Elysia routes the request, so the vulnerable handler is
+            // never invoked. We assert the filesystem stays untouched for every
+            // affected endpoint to document this defence-in-depth layer.
+            const { touched } = spyFs();
+
+            for (const makeUrl of ENDPOINTS) {
+                const res = await app.handle(new Request(makeUrl('..')));
+                expect(res.status).toBe(404);
+            }
+
+            expect(touched).toHaveLength(0);
+
+            resetDependencies();
+        });
+
+        it('still resolves a legitimate slug theme name (no false positives)', async () => {
+            // The "base" theme is bundled and must keep working after hardening.
+            const metaRes = await app.handle(new Request('http://localhost/api/themes/installed/base'));
+            expect(metaRes.status).toBe(200);
+            const meta = await metaRes.json();
+            expect(meta.dirName).toBe('base');
+
+            const bundleRes = await app.handle(new Request('http://localhost/api/resources/theme/base/bundle'));
+            expect(bundleRes.status).toBe(200);
+            const bundle = await bundleRes.json();
+            expect(bundle.themeName).toBe('base');
+            expect(Object.keys(bundle.files).length).toBeGreaterThan(0);
+
+            const downloadRes = await app.handle(new Request('http://localhost/api/themes/base/download'));
+            expect(downloadRes.status).toBe(200);
+            const download = await downloadRes.json();
+            expect(download.zipFileName).toBe('base.zip');
+        });
+
+        it('accepts names with hyphens and underscores (valid slug charset)', async () => {
+            // A site theme dir_name like "my_cool-theme" is a valid slug; the guard
+            // must not reject it. It does not exist on disk, so the handler reaches
+            // the filesystem and returns the normal not-found response.
+            const { touched } = spyFs();
+
+            const res = await app.handle(new Request('http://localhost/api/themes/installed/my_cool-theme'));
+
+            expect(res.status).toBe(404);
+            // The guard let it through, so the filesystem WAS consulted.
+            expect(touched.length).toBeGreaterThan(0);
+            // Every consulted path stays inside an expected themes base directory.
+            for (const p of touched) {
+                expect(p.includes('themes/base') || p.includes('themes/site')).toBe(true);
+            }
+
+            resetDependencies();
+        });
+    });
 });

--- a/src/routes/themes.ts
+++ b/src/routes/themes.ts
@@ -14,6 +14,7 @@ import { getEnabledSiteThemes, getDefaultTheme, getBaseThemes } from '../db/quer
 import type { Theme } from '../db/types';
 import { buildSiteThemeUrl } from '../utils/site-theme-url';
 import { prefixPath } from '../utils/basepath.util';
+import { isSafePathSegment, safeJoin, isWithinBase } from '../utils/safe-path';
 
 // Base path for themes (bundled with the app)
 const THEMES_BASE_PATH = 'public/files/perm/themes/base';
@@ -417,16 +418,24 @@ export const themesRoutes = new Elysia({ name: 'themes-routes' })
     .get('/api/themes/installed/:themeId', ({ params, set }) => {
         const { themeId } = params;
 
+        // Theme ids are slugs ([a-z0-9_-]); reject any traversal/separator before
+        // it reaches `path.join`. Elysia decodes `%2F` to a real separator, so an
+        // unvalidated id would allow reading config.xml-like files outside the base.
+        if (!isSafePathSegment(themeId)) {
+            set.status = 404;
+            return { error: 'Not Found', message: `Theme ${themeId} not found` };
+        }
+
         // Check base themes first
-        let configPath = path.join(THEMES_BASE_PATH, themeId, 'config.xml');
-        let themePath = path.join(THEMES_BASE_PATH, themeId);
+        let configPath = safeJoin(THEMES_BASE_PATH, themeId, 'config.xml');
+        let themePath = safeJoin(THEMES_BASE_PATH, themeId);
         let type: 'base' | 'site' = 'base';
 
         if (!deps.fs.existsSync(configPath)) {
             // Check site themes
             const siteThemesPath = getSiteThemesPath();
-            configPath = path.join(siteThemesPath, themeId, 'config.xml');
-            themePath = path.join(siteThemesPath, themeId);
+            configPath = safeJoin(siteThemesPath, themeId, 'config.xml');
+            themePath = safeJoin(siteThemesPath, themeId);
             type = 'site';
         }
 
@@ -452,18 +461,34 @@ export const themesRoutes = new Elysia({ name: 'themes-routes' })
     .get('/api/resources/theme/:themeName/bundle', async ({ params, set }) => {
         const { themeName } = params;
 
+        // Theme names are slugs ([a-z0-9_-]); reject any traversal/separator before
+        // it reaches `path.join`. Without this, an attacker could escape the base
+        // (Elysia decodes `%2F` to a real separator) and have the recursive scan
+        // below read arbitrary files (e.g. .env, the DB) the process can access.
+        if (!isSafePathSegment(themeName)) {
+            set.status = 404;
+            return { error: 'Not Found', message: `Theme ${themeName} not found` };
+        }
+
         // Check base themes first
-        let themePath = path.join(THEMES_BASE_PATH, themeName);
+        let baseDir = THEMES_BASE_PATH;
+        let themePath = safeJoin(baseDir, themeName);
         let found = deps.fs.existsSync(themePath);
 
         if (!found) {
             // Check site themes
-            const siteThemesPath = getSiteThemesPath();
-            themePath = path.join(siteThemesPath, themeName);
+            baseDir = getSiteThemesPath();
+            themePath = safeJoin(baseDir, themeName);
             found = deps.fs.existsSync(themePath);
         }
 
         if (!found) {
+            set.status = 404;
+            return { error: 'Not Found', message: `Theme ${themeName} not found` };
+        }
+
+        // Defence in depth: never recurse outside the resolved theme directory.
+        if (!isWithinBase(baseDir, themePath)) {
             set.status = 404;
             return { error: 'Not Found', message: `Theme ${themeName} not found` };
         }
@@ -473,6 +498,8 @@ export const themesRoutes = new Elysia({ name: 'themes-routes' })
 
         function scanDir(dirPath: string, prefix = ''): void {
             if (!deps.fs.existsSync(dirPath)) return;
+            // Guard against symlinks/entries that would escape the theme directory.
+            if (!isWithinBase(themePath, dirPath)) return;
 
             const entries = deps.fs.readdirSync(dirPath, { withFileTypes: true });
             for (const entry of entries) {
@@ -501,19 +528,35 @@ export const themesRoutes = new Elysia({ name: 'themes-routes' })
     .get('/api/themes/:themeId/download', async ({ params, set }) => {
         const { themeId } = params;
 
+        // Theme ids are slugs ([a-z0-9_-]); reject any traversal/separator before
+        // it reaches `path.join`. Without this, an attacker could escape the base
+        // (Elysia decodes `%2F` to a real separator) and have `createZipBuffer`
+        // recursively read and exfiltrate arbitrary directories.
+        if (!isSafePathSegment(themeId)) {
+            set.status = 404;
+            return { error: 'Not Found', message: `Theme ${themeId} not found` };
+        }
+
         // Check base themes first
-        let themePath = path.join(THEMES_BASE_PATH, themeId);
+        let baseDir = THEMES_BASE_PATH;
+        let themePath = safeJoin(baseDir, themeId);
         let found = deps.fs.existsSync(themePath);
         let themeName = themeId;
 
         if (!found) {
             // Check site themes
-            const siteThemesPath = getSiteThemesPath();
-            themePath = path.join(siteThemesPath, themeId);
+            baseDir = getSiteThemesPath();
+            themePath = safeJoin(baseDir, themeId);
             found = deps.fs.existsSync(themePath);
         }
 
         if (!found) {
+            set.status = 404;
+            return { error: 'Not Found', message: `Theme ${themeId} not found` };
+        }
+
+        // Defence in depth: never zip a directory that escaped the theme base.
+        if (!isWithinBase(baseDir, themePath)) {
             set.status = 404;
             return { error: 'Not Found', message: `Theme ${themeId} not found` };
         }

--- a/src/routes/upload-session.spec.ts
+++ b/src/routes/upload-session.spec.ts
@@ -13,6 +13,7 @@ import {
     emitBatchComplete,
     deleteSession,
     MAX_BATCH_FILES,
+    MAX_BATCH_BYTES,
 } from '../services/upload-session-manager';
 import type { Database } from '../db/types';
 import type { Kysely } from 'kysely';
@@ -861,6 +862,149 @@ describe('Upload Session Routes - Path Traversal Security (C1)', () => {
         const assetFiles = await fs.readdir(assetsDir);
         expect(assetFiles).toContain('safe-asset-1.txt');
         expect(assetFiles).toContain('safe_asset-2.png');
+    });
+});
+
+describe('Upload Session Routes - Batch Size Limit (L1, memory DoS)', () => {
+    let app: Elysia;
+    let sessionToken: string;
+    let mockQueries: ReturnType<typeof createMockQueries>;
+    const projectUuid = 'batch-size-limit-project';
+    const assetsDir = path.join(TEST_DIR, 'assets', projectUuid);
+
+    beforeEach(async () => {
+        await fs.ensureDir(TEST_DIR);
+        await fs.emptyDir(TEST_DIR);
+        process.env.ELYSIA_FILES_DIR = TEST_DIR;
+
+        mockQueries = createMockQueries();
+
+        const result = await testSessionManager.createSession({
+            projectId: projectUuid,
+            projectIdNum: 88,
+            userId: 1,
+            clientId: 'batch-size-limit-client',
+            totalFiles: 5,
+            totalBytes: 5000,
+        });
+        sessionToken = result.sessionToken;
+
+        const routes = createUploadSessionRoutes({
+            db: createMockDb(),
+            queries: mockQueries as unknown as UploadSessionDependencies['queries'],
+        });
+        app = new Elysia().use(routes);
+
+        await fs.ensureDir(assetsDir);
+    });
+
+    afterEach(async () => {
+        await fs.remove(TEST_DIR);
+    });
+
+    it('rejects a batch whose declared total exceeds MAX_BATCH_BYTES before buffering or writing', async () => {
+        // Two Blobs whose declared `.size` sum to well over the cap. The early declared-size check
+        // must reject the batch before any file is buffered into memory or written to disk.
+        const halfPlus = Math.ceil(MAX_BATCH_BYTES / 2) + 1024 * 1024; // each just over half the cap
+        const chunk = Buffer.alloc(halfPlus, 'x');
+
+        const formData = new FormData();
+        formData.append(
+            'metadata',
+            JSON.stringify([
+                { clientId: 'big-1', filename: 'big1.bin', mimeType: 'application/octet-stream' },
+                { clientId: 'big-2', filename: 'big2.bin', mimeType: 'application/octet-stream' },
+            ]),
+        );
+        formData.append('files', new Blob([chunk], { type: 'application/octet-stream' }));
+        formData.append('files', new Blob([chunk], { type: 'application/octet-stream' }));
+
+        const response = await app.handle(
+            new Request(`http://localhost/api/upload-session/${sessionToken}/batch`, {
+                method: 'POST',
+                body: formData,
+            }),
+        );
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.success).toBe(false);
+        expect(data.error).toContain('Batch too large');
+        expect(data.error).toContain('100MB');
+
+        // Nothing was buffered to disk and no asset records were created/updated: the cap was
+        // enforced before the buffering and persistence phases.
+        const assetFiles = await fs.readdir(assetsDir);
+        expect(assetFiles.length).toBe(0);
+        expect(mockQueries.createAssets).not.toHaveBeenCalled();
+        expect(mockQueries.bulkUpdateAssets).not.toHaveBeenCalled();
+    });
+
+    it('rejects a batch where the declared total first exceeds the cap on a later file', async () => {
+        // The running declared total only crosses the cap on the last file. The handler must still
+        // reject the whole batch and persist nothing.
+        const small = Buffer.alloc(1024, 'a'); // 1KB
+        const huge = Buffer.alloc(MAX_BATCH_BYTES, 'b'); // exactly the cap, so total > cap
+
+        const formData = new FormData();
+        formData.append(
+            'metadata',
+            JSON.stringify([
+                { clientId: 'small-1', filename: 'small.txt', mimeType: 'text/plain' },
+                { clientId: 'huge-1', filename: 'huge.bin', mimeType: 'application/octet-stream' },
+            ]),
+        );
+        formData.append('files', new Blob([small], { type: 'text/plain' }));
+        formData.append('files', new Blob([huge], { type: 'application/octet-stream' }));
+
+        const response = await app.handle(
+            new Request(`http://localhost/api/upload-session/${sessionToken}/batch`, {
+                method: 'POST',
+                body: formData,
+            }),
+        );
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.success).toBe(false);
+        expect(data.error).toContain('Batch too large');
+
+        const assetFiles = await fs.readdir(assetsDir);
+        expect(assetFiles.length).toBe(0);
+        expect(mockQueries.createAssets).not.toHaveBeenCalled();
+    });
+
+    it('accepts a batch that is comfortably within MAX_BATCH_BYTES', async () => {
+        // A legitimate batch under the cap must still succeed exactly as before.
+        const content = Buffer.alloc(2 * 1024 * 1024, 'z'); // 2MB total, well under 100MB
+
+        const formData = new FormData();
+        formData.append(
+            'metadata',
+            JSON.stringify([
+                { clientId: 'within-1', filename: 'a.bin', mimeType: 'application/octet-stream' },
+                { clientId: 'within-2', filename: 'b.bin', mimeType: 'application/octet-stream' },
+            ]),
+        );
+        formData.append('files', new Blob([content], { type: 'application/octet-stream' }));
+        formData.append('files', new Blob([content], { type: 'application/octet-stream' }));
+
+        const response = await app.handle(
+            new Request(`http://localhost/api/upload-session/${sessionToken}/batch`, {
+                method: 'POST',
+                body: formData,
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.uploaded).toBe(2);
+        expect(data.failed).toBe(0);
+
+        const assetFiles = await fs.readdir(assetsDir);
+        expect(assetFiles).toContain('within-1.bin');
+        expect(assetFiles).toContain('within-2.bin');
     });
 });
 

--- a/src/routes/upload-session.spec.ts
+++ b/src/routes/upload-session.spec.ts
@@ -708,6 +708,162 @@ describe('Upload Session Routes - Edge Cases', () => {
     });
 });
 
+describe('Upload Session Routes - Path Traversal Security (C1)', () => {
+    let app: Elysia;
+    let sessionToken: string;
+    let mockQueries: ReturnType<typeof createMockQueries>;
+    const projectUuid = 'traversal-security-project';
+    const assetsDir = path.join(TEST_DIR, 'assets', projectUuid);
+
+    beforeEach(async () => {
+        await fs.ensureDir(TEST_DIR);
+        await fs.emptyDir(TEST_DIR);
+        process.env.ELYSIA_FILES_DIR = TEST_DIR;
+
+        mockQueries = {
+            createAssets: mock((_db: Kysely<Database>, assets: Array<{ client_id: string }>) =>
+                Promise.resolve(assets.map((a, i) => ({ id: i + 1000, client_id: a.client_id }))),
+            ),
+            findAssetsByClientIds: mock(() => Promise.resolve([])),
+            bulkUpdateAssets: mock(() => Promise.resolve()),
+            findProjectByUuid: mock(() => Promise.resolve({ id: 55, uuid: projectUuid, user_id: 1 })),
+        };
+
+        const result = await testSessionManager.createSession({
+            projectId: projectUuid,
+            projectIdNum: 55,
+            userId: 1,
+            clientId: 'traversal-security-client',
+            totalFiles: 5,
+            totalBytes: 5000,
+        });
+        sessionToken = result.sessionToken;
+
+        const routes = createUploadSessionRoutes({
+            db: createMockDb(),
+            queries: mockQueries as unknown as UploadSessionDependencies['queries'],
+        });
+        app = new Elysia().use(routes);
+
+        await fs.ensureDir(assetsDir);
+    });
+
+    afterEach(async () => {
+        await fs.remove(TEST_DIR);
+    });
+
+    it('should reject a batch whose clientId attempts path traversal and write nothing', async () => {
+        const formData = new FormData();
+        formData.append(
+            'metadata',
+            JSON.stringify([{ clientId: '../../../../tmp/evil', filename: 'pwn.txt', mimeType: 'text/plain' }]),
+        );
+        formData.append('files', new Blob(['malicious content'], { type: 'text/plain' }));
+
+        const response = await app.handle(
+            new Request(`http://localhost/api/upload-session/${sessionToken}/batch`, {
+                method: 'POST',
+                body: formData,
+            }),
+        );
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.success).toBe(false);
+        expect(data.error).toBe('Invalid clientId in metadata');
+
+        // Nothing should have been written to disk and no DB inserts attempted.
+        const assetFiles = await fs.readdir(assetsDir);
+        expect(assetFiles.length).toBe(0);
+        expect(mockQueries.createAssets).not.toHaveBeenCalled();
+        expect(mockQueries.bulkUpdateAssets).not.toHaveBeenCalled();
+    });
+
+    it('should reject a batch when ANY clientId is unsafe (mixed with a valid one) and write nothing', async () => {
+        const formData = new FormData();
+        formData.append(
+            'metadata',
+            JSON.stringify([
+                { clientId: 'safe-asset', filename: 'ok.txt', mimeType: 'text/plain' },
+                { clientId: 'a/../../escape', filename: 'pwn.txt', mimeType: 'text/plain' },
+            ]),
+        );
+        formData.append('files', new Blob(['ok content'], { type: 'text/plain' }));
+        formData.append('files', new Blob(['evil content'], { type: 'text/plain' }));
+
+        const response = await app.handle(
+            new Request(`http://localhost/api/upload-session/${sessionToken}/batch`, {
+                method: 'POST',
+                body: formData,
+            }),
+        );
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.success).toBe(false);
+        expect(data.error).toBe('Invalid clientId in metadata');
+
+        // The whole batch is rejected before any write, so even the "safe" file is not written.
+        const assetFiles = await fs.readdir(assetsDir);
+        expect(assetFiles.length).toBe(0);
+        expect(mockQueries.createAssets).not.toHaveBeenCalled();
+    });
+
+    it('should reject an absolute-path clientId and write nothing', async () => {
+        const formData = new FormData();
+        formData.append(
+            'metadata',
+            JSON.stringify([{ clientId: '/etc/cron.d/evil', filename: 'job', mimeType: 'text/plain' }]),
+        );
+        formData.append('files', new Blob(['cron payload'], { type: 'text/plain' }));
+
+        const response = await app.handle(
+            new Request(`http://localhost/api/upload-session/${sessionToken}/batch`, {
+                method: 'POST',
+                body: formData,
+            }),
+        );
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.error).toBe('Invalid clientId in metadata');
+
+        const assetFiles = await fs.readdir(assetsDir);
+        expect(assetFiles.length).toBe(0);
+    });
+
+    it('should still accept a normal batch with safe clientIds and write the files', async () => {
+        const formData = new FormData();
+        formData.append(
+            'metadata',
+            JSON.stringify([
+                { clientId: 'safe-asset-1', filename: 'a.txt', mimeType: 'text/plain' },
+                { clientId: 'safe_asset-2', filename: 'b.png', mimeType: 'image/png' },
+            ]),
+        );
+        formData.append('files', new Blob(['content one'], { type: 'text/plain' }));
+        formData.append('files', new Blob(['content two'], { type: 'image/png' }));
+
+        const response = await app.handle(
+            new Request(`http://localhost/api/upload-session/${sessionToken}/batch`, {
+                method: 'POST',
+                body: formData,
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.uploaded).toBe(2);
+        expect(data.failed).toBe(0);
+
+        // Files are written inside the project assets dir using the clientId + sanitized extension.
+        const assetFiles = await fs.readdir(assetsDir);
+        expect(assetFiles).toContain('safe-asset-1.txt');
+        expect(assetFiles).toContain('safe_asset-2.png');
+    });
+});
+
 describe('Upload Session Exports', () => {
     it('should export validateSession function', () => {
         expect(typeof validateSession).toBe('function');

--- a/src/routes/upload-session.ts
+++ b/src/routes/upload-session.ts
@@ -12,7 +12,6 @@
  */
 import { Elysia } from 'elysia';
 import * as fs from 'fs-extra';
-import * as path from 'path';
 import type { Kysely } from 'kysely';
 
 import { db } from '../db/client';
@@ -20,6 +19,7 @@ import type { Database } from '../db/types';
 import { createAssets, findAssetsByClientIds, bulkUpdateAssets, findProjectByUuid } from '../db/queries';
 
 import { getProjectAssetsDir } from '../services/file-helper';
+import { isSafePathSegment, safeJoin, sanitizeFileExtension } from '../utils/safe-path';
 import {
     uploadSessionManager,
     validateSession,
@@ -153,6 +153,18 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                         };
                     }
 
+                    // Each effective clientId becomes an on-disk filename; reject traversal/separators
+                    // up front so nothing is written when any clientId is unsafe. The session JWT binds
+                    // only projectId, not the per-file clientId, so the metadata is untrusted input.
+                    // Mirror the per-file fallback used below: a missing metadata entry yields `file-${i}`.
+                    for (let i = 0; i < files.length; i++) {
+                        const clientId = (metadata[i] || { clientId: `file-${i}` }).clientId;
+                        if (!isSafePathSegment(clientId)) {
+                            set.status = 400;
+                            return { success: false, error: 'Invalid clientId in metadata' };
+                        }
+                    }
+
                     // Get base storage path using project UUID
                     const baseStoragePath = getProjectAssetsDir(session.projectId);
                     await fs.ensureDir(baseStoragePath);
@@ -182,10 +194,12 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                             fileBuffer = Buffer.from(file as unknown as ArrayBuffer);
                         }
 
-                        // Use clientId as filename with original extension
-                        const ext = path.extname(filename).toLowerCase();
+                        // Use clientId as filename with original extension. clientId was validated as a
+                        // safe path segment above; safeJoin re-validates and asserts containment so a
+                        // crafted clientId or extension cannot escape the project assets directory.
+                        const ext = sanitizeFileExtension(filename);
                         const flatFilename = `${fileMeta.clientId}${ext}`;
-                        const filePath = path.join(baseStoragePath, flatFilename);
+                        const filePath = safeJoin(baseStoragePath, flatFilename);
 
                         return {
                             clientId: fileMeta.clientId,

--- a/src/routes/upload-session.ts
+++ b/src/routes/upload-session.ts
@@ -165,15 +165,53 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                         }
                     }
 
+                    // Enforce the total batch size BEFORE buffering any bytes into memory.
+                    // Blob/File expose `.size` and Buffer exposes `.length` without reading the
+                    // payload, so we can reject an oversized batch using the declared sizes and never
+                    // materialize the files. This closes a memory-amplification vector under concurrency
+                    // where many large batches would otherwise be fully buffered before the cap is hit.
+                    let declaredBatchBytes = 0;
+                    for (const file of files) {
+                        if (file instanceof Blob) {
+                            declaredBatchBytes += file.size;
+                        } else if (Buffer.isBuffer(file)) {
+                            declaredBatchBytes += file.length;
+                        }
+                        if (declaredBatchBytes > MAX_BATCH_BYTES) {
+                            set.status = 400;
+                            return {
+                                success: false,
+                                error: `Batch too large. Maximum is ${MAX_BATCH_BYTES / (1024 * 1024)}MB per batch.`,
+                            };
+                        }
+                    }
+
                     // Get base storage path using project UUID
                     const baseStoragePath = getProjectAssetsDir(session.projectId);
                     await fs.ensureDir(baseStoragePath);
 
                     // =====================================================
-                    // PHASE 1: Convert all files to buffers in parallel
+                    // PHASE 1: Convert files to buffers sequentially, aborting early
                     // Emit progress for each file as we process it
                     // =====================================================
-                    const fileDataPromises = files.map(async (file, i) => {
+                    // Buffer one file at a time and track the running total instead of materializing
+                    // the whole set with Promise.all. This bounds peak memory and lets us abort as soon
+                    // as the actual buffered bytes exceed MAX_BATCH_BYTES, even when a declared `.size`
+                    // was missing or under-reported above.
+                    type BufferedFile = {
+                        clientId: string;
+                        filename: string;
+                        mimeType: string;
+                        folderPath: string;
+                        fileBuffer: Buffer;
+                        filePath: string;
+                        flatFilename: string;
+                    };
+                    const fileData: BufferedFile[] = [];
+                    let bufferedBatchBytes = 0;
+
+                    for (let i = 0; i < files.length; i++) {
+                        const file = files[i];
                         const fileMeta = metadata[i] || {
                             clientId: `file-${i}`,
                             filename: 'unknown',
@@ -194,6 +232,18 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                             fileBuffer = Buffer.from(file as unknown as ArrayBuffer);
                         }
 
+                        // Abort as soon as the actual buffered total exceeds the cap. Releasing the
+                        // already-buffered files (and not buffering the rest) keeps peak memory bounded.
+                        bufferedBatchBytes += fileBuffer.length;
+                        if (bufferedBatchBytes > MAX_BATCH_BYTES) {
+                            fileData.length = 0;
+                            set.status = 400;
+                            return {
+                                success: false,
+                                error: `Batch too large. Maximum is ${MAX_BATCH_BYTES / (1024 * 1024)}MB per batch.`,
+                            };
+                        }
+
                         // Use clientId as filename with original extension. clientId was validated as a
                         // safe path segment above; safeJoin re-validates and asserts containment so a
                         // crafted clientId or extension cannot escape the project assets directory.
@@ -201,7 +251,7 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                         const flatFilename = `${fileMeta.clientId}${ext}`;
                         const filePath = safeJoin(baseStoragePath, flatFilename);
 
-                        return {
+                        fileData.push({
                             clientId: fileMeta.clientId,
                             filename,
                             mimeType,
@@ -209,19 +259,7 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                             fileBuffer,
                             filePath,
                             flatFilename,
-                        };
-                    });
-
-                    const fileData = await Promise.all(fileDataPromises);
-
-                    // Check total batch size
-                    const totalBatchBytes = fileData.reduce((sum, f) => sum + f.fileBuffer.length, 0);
-                    if (totalBatchBytes > MAX_BATCH_BYTES) {
-                        set.status = 400;
-                        return {
-                            success: false,
-                            error: `Batch too large. Maximum is ${MAX_BATCH_BYTES / (1024 * 1024)}MB per batch.`,
-                        };
+                        });
                     }
 
                     // =====================================================

--- a/src/routes/user.spec.ts
+++ b/src/routes/user.spec.ts
@@ -7,15 +7,17 @@ import { Elysia } from 'elysia';
 import { jwt } from '@elysiajs/jwt';
 import { createUserRoutes, type UserDependencies } from './user';
 
-// Test JWT secret (must match what user.ts uses)
-const TEST_JWT_SECRET = process.env.APP_SECRET || 'test-secret-for-user-routes-testing';
+// Test JWT secret (must match what user.ts verifies with).
+const TEST_JWT_SECRET = 'test-secret-for-user-routes-testing';
 
-// Override APP_SECRET for tests
+// Save originals so each test restores them and never leaks the test secret to
+// other suites in the same Bun process.
 const originalAppSecret = process.env.APP_SECRET;
-// user.ts:getJwtSecret() prefers JWT_SECRET over APP_SECRET. Other specs in the
-// same Bun process (auth.spec.ts, admin.spec.ts, api/v1/*.spec.ts, ...) set
-// process.env.JWT_SECRET and don't clean it up, which would make jwt.verify()
-// use a different secret than the one this test signs with, breaking auth.
+// The canonical resolver (auth.ts:getJwtSecret) prefers API_JWT_SECRET over
+// JWT_SECRET over the public default. The test env sets API_JWT_SECRET via .env,
+// so we must override API_JWT_SECRET (not just JWT_SECRET/APP_SECRET) to the value
+// this spec signs with, otherwise jwt.verify() uses a different secret and auth fails.
+const originalApiJwtSecret = process.env.API_JWT_SECRET;
 const originalJwtSecret = process.env.JWT_SECRET;
 
 describe('User Routes', () => {
@@ -72,8 +74,10 @@ describe('User Routes', () => {
     }
 
     beforeEach(async () => {
-        // Set test secret on both vars so getJwtSecret() (JWT_SECRET || APP_SECRET)
-        // always resolves to the same value this spec signs with.
+        // Set all three vars so the canonical resolver (API_JWT_SECRET || JWT_SECRET
+        // || default) always resolves to the value this spec signs with. Routes are
+        // created below in this hook, after the env is set.
+        process.env.API_JWT_SECRET = TEST_JWT_SECRET;
         process.env.APP_SECRET = TEST_JWT_SECRET;
         process.env.JWT_SECRET = TEST_JWT_SECRET;
 
@@ -114,8 +118,13 @@ describe('User Routes', () => {
     });
 
     afterEach(() => {
-        // Restore original APP_SECRET / JWT_SECRET
-        if (originalAppSecret) {
+        // Restore original API_JWT_SECRET / APP_SECRET / JWT_SECRET
+        if (originalApiJwtSecret !== undefined) {
+            process.env.API_JWT_SECRET = originalApiJwtSecret;
+        } else {
+            delete process.env.API_JWT_SECRET;
+        }
+        if (originalAppSecret !== undefined) {
             process.env.APP_SECRET = originalAppSecret;
         } else {
             delete process.env.APP_SECRET;

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -3,6 +3,7 @@
  * Handles user preferences and settings
  */
 import { Elysia } from 'elysia';
+import { getJwtSecret } from './auth';
 import { cookie } from '@elysiajs/cookie';
 import { jwt } from '@elysiajs/jwt';
 import { db } from '../db/client';
@@ -23,11 +24,6 @@ import type { JwtPayload, UserPreferencesRequest } from './types/request-payload
 interface PreferenceValue {
     value: string | number | boolean;
 }
-
-// Get JWT secret (same as auth.ts)
-const getJwtSecret = () => {
-    return process.env.JWT_SECRET || process.env.APP_SECRET || 'elysia-dev-secret-change-me';
-};
 
 /**
  * Default user preferences with structure expected by frontend

--- a/src/routes/yjs.spec.ts
+++ b/src/routes/yjs.spec.ts
@@ -5,7 +5,20 @@
 import { describe, it, expect, beforeEach, beforeAll } from 'bun:test';
 import { Elysia } from 'elysia';
 import { SignJWT } from 'jose';
+import * as Y from 'yjs';
 import { createYjsRoutes, type YjsDependencies } from './yjs';
+
+// A real Yjs update used to exercise the snapshot+updates reconstruction path
+// (a project whose server-side state lives only in yjs_updates, e.g. edited via
+// the REST API v1). Building it here keeps the mock query deterministic.
+function buildUpdatesOnlyRows(): Array<{ update_data: Uint8Array; version: string }> {
+    const doc = new Y.Doc();
+    doc.getMap('metadata').set('title', 'From updates only');
+    const update = Y.encodeStateAsUpdate(doc);
+    doc.destroy();
+    return [{ update_data: update, version: Date.now().toString() }];
+}
+const updatesOnlyRows = buildUpdatesOnlyRows();
 
 // Use the same fallback secret that getJwtSecret() returns when no env var is
 // set. We intentionally do NOT mutate process.env here — tests run in the same
@@ -72,6 +85,9 @@ describe('Yjs Document Routes', () => {
                     if (uuid === 'no-snapshot-uuid') {
                         return { ...mockProject, uuid: 'no-snapshot-uuid', id: 2 } as any;
                     }
+                    if (uuid === 'updates-only-uuid') {
+                        return { ...mockProject, uuid: 'updates-only-uuid', id: 3 } as any;
+                    }
                     return undefined;
                 },
                 findSnapshotByProjectId: async (_db: any, projectId: number) => {
@@ -82,6 +98,16 @@ describe('Yjs Document Routes', () => {
                         return mockSnapshot;
                     }
                     return undefined;
+                },
+                loadDocumentWithUpdates: async (_db: any, projectId: number) => {
+                    // Mirror the snapshot mock; project 3 has updates but no snapshot.
+                    const snapshot = savedSnapshots.has(projectId)
+                        ? savedSnapshots.get(projectId)
+                        : projectId === 1
+                          ? mockSnapshot
+                          : undefined;
+                    const updates = projectId === 3 ? updatesOnlyRows : [];
+                    return { snapshot, updates } as any;
                 },
                 upsertSnapshot: async (_db: any, projectId: number, data: Uint8Array, version: string) => {
                     savedSnapshots.set(projectId, {
@@ -260,6 +286,26 @@ describe('Yjs Document Routes', () => {
             const buffer = await res.arrayBuffer();
             const data = new Uint8Array(buffer);
             expect(data).toEqual(mockSnapshot.snapshot_data);
+        });
+
+        it('reconstructs a document that exists only as updates, with no snapshot (H5)', async () => {
+            // Project 3 has no yjs_documents snapshot, only a yjs_updates row.
+            // The old endpoint returned 404; it must now return the merged state.
+            const res = await app.handle(
+                new Request('http://localhost/api/projects/uuid/updates-only-uuid/yjs-document', {
+                    headers: { Authorization: `Bearer ${ownerToken}` },
+                }),
+            );
+
+            expect(res.status).toBe(200);
+            expect(res.headers.get('Content-Type')).toBe('application/octet-stream');
+
+            // The returned bytes must apply cleanly and contain the edit.
+            const merged = new Uint8Array(await res.arrayBuffer());
+            const doc = new Y.Doc();
+            Y.applyUpdate(doc, merged);
+            expect(doc.getMap('metadata').get('title')).toBe('From updates only');
+            doc.destroy();
         });
     });
 

--- a/src/routes/yjs.ts
+++ b/src/routes/yjs.ts
@@ -9,6 +9,7 @@ import {
     findProjectByUuid,
     upsertSnapshot,
     findSnapshotByProjectId,
+    loadDocumentWithUpdates,
     updateProjectTitle,
     updateProjectTitleAndSave,
     checkProjectAccess,
@@ -26,6 +27,7 @@ import type { Database } from '../db/types';
 export interface YjsQueries {
     findProjectByUuid: typeof findProjectByUuid;
     findSnapshotByProjectId: typeof findSnapshotByProjectId;
+    loadDocumentWithUpdates: typeof loadDocumentWithUpdates;
     upsertSnapshot: typeof upsertSnapshot;
     updateProjectTitle: typeof updateProjectTitle;
     updateProjectTitleAndSave: typeof updateProjectTitleAndSave;
@@ -48,6 +50,7 @@ const defaultDependencies: YjsDependencies = {
     queries: {
         findProjectByUuid,
         findSnapshotByProjectId,
+        loadDocumentWithUpdates,
         upsertSnapshot,
         updateProjectTitle,
         updateProjectTitleAndSave,
@@ -119,20 +122,40 @@ export function createYjsRoutes(deps: YjsDependencies = defaultDependencies) {
                     }
                 }
 
-                const snapshot = await queries.findSnapshotByProjectId(database, project.id);
-                if (!snapshot) {
+                // Read the canonical snapshot AND any incremental updates. The
+                // previous code returned only the snapshot, so a project whose
+                // server-side state lives in yjs_updates (e.g. edited via REST
+                // API v1) loaded as empty / 404 even though content existed (H5).
+                const { snapshot, updates } = await queries.loadDocumentWithUpdates(database, project.id);
+                if (!snapshot && updates.length === 0) {
                     return new Response(JSON.stringify({ error: 'Not Found', message: 'No document saved' }), {
                         status: 404,
                         headers: { 'Content-Type': 'application/json' },
                     });
                 }
 
-                // Convert database data to Uint8Array
-                // MySQL with Bun.SQL stores as base64, SQLite/PostgreSQL as binary
-                const binaryData = fromBinaryData(snapshot.snapshot_data);
+                // Fast path: a snapshot with no newer updates is returned as-is
+                // (avoids decoding the Y.Doc on the common browser-save case).
+                if (snapshot && updates.length === 0) {
+                    return new Response(fromBinaryData(snapshot.snapshot_data), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/octet-stream' },
+                    });
+                }
 
-                // Return raw binary response - using Response object ensures proper binary handling
-                return new Response(binaryData, {
+                // Otherwise merge snapshot + updates into a single state vector.
+                const Y = await import('yjs');
+                const ydoc = new Y.Doc();
+                if (snapshot) {
+                    Y.applyUpdate(ydoc, fromBinaryData(snapshot.snapshot_data));
+                }
+                for (const update of updates) {
+                    Y.applyUpdate(ydoc, fromBinaryData(update.update_data));
+                }
+                const mergedState = Y.encodeStateAsUpdate(ydoc);
+                ydoc.destroy();
+
+                return new Response(mergedState, {
                     status: 200,
                     headers: { 'Content-Type': 'application/octet-stream' },
                 });

--- a/src/services/file-helper.spec.ts
+++ b/src/services/file-helper.spec.ts
@@ -192,6 +192,18 @@ describe('File Helper Service', () => {
             expect(fileHelper.isPathSafe('/base', '/base/subdir')).toBe(true);
             expect(fileHelper.isPathSafe('/base', '/other/path')).toBe(false);
         });
+
+        it('should not treat a sibling sharing a name prefix as inside the base', () => {
+            // Regression: a naive startsWith(resolvedBase) check would accept
+            // `/base-evil` as inside `/base`. The separator-aware check rejects it.
+            expect(fileHelper.isPathSafe('/base', '../base-evil/secret')).toBe(false);
+            expect(fileHelper.isPathSafe('/data/assets', '../assets-evil/x')).toBe(false);
+        });
+
+        it('should accept the base path itself', () => {
+            expect(fileHelper.isPathSafe('/base', '.')).toBe(true);
+            expect(fileHelper.isPathSafe('/base', '/base')).toBe(true);
+        });
     });
 
     describe('getContentXmlPath', () => {

--- a/src/services/file-helper.ts
+++ b/src/services/file-helper.ts
@@ -189,7 +189,9 @@ export function createFileHelper(deps: FileHelperDeps = {}): FileHelper {
     const isPathSafe = (basePath: string, targetPath: string): boolean => {
         const resolvedBase = path.resolve(basePath);
         const resolvedTarget = path.resolve(basePath, targetPath);
-        return resolvedTarget.startsWith(resolvedBase);
+        // Separator-aware containment check. A naive `startsWith(resolvedBase)`
+        // would treat `/data/assets-evil` as inside `/data/assets`.
+        return resolvedTarget === resolvedBase || resolvedTarget.startsWith(resolvedBase + path.sep);
     };
 
     const generateUniqueFilename = (originalName: string): string => {

--- a/src/services/link-validator.spec.ts
+++ b/src/services/link-validator.spec.ts
@@ -15,6 +15,23 @@ import {
     type RawExtractedLink,
     type IdeviceContent,
 } from './link-validator';
+import type { LookupFn } from '../utils/ssrf-guard';
+
+// A DNS resolver that maps any host to a single public IP, so the SSRF guard
+// allows the request and control reaches the (mocked) fetch. Keeps tests
+// hermetic: no real DNS or network is touched.
+const publicLookup: LookupFn = async () => [{ address: '93.184.216.34' }];
+
+// Helper to build a minimal Response-like mock that includes a working
+// `headers.get()` so safeFetch can inspect the Location header. Pass a
+// `location` to simulate a redirect hop.
+function mockResponse(init: { status: number; ok: boolean; location?: string }): Response {
+    const headers = new Headers();
+    if (init.location) {
+        headers.set('location', init.location);
+    }
+    return { status: init.status, ok: init.ok, headers } as Response;
+}
 
 describe('Link Validator Service', () => {
     describe('extractLinksFromHtml', () => {
@@ -278,6 +295,9 @@ describe('Link Validator Service', () => {
                 const result = await validateLink('https://this-domain-definitely-does-not-exist-12345.com', {
                     filesDir: tempDir,
                     timeout: 5000,
+                    // Resolve to a public IP so the SSRF guard allows the host and
+                    // control reaches the (mocked) fetch which throws ENOTFOUND.
+                    lookupFn: publicLookup,
                 });
                 expect(result).toBe('Could not resolve host');
             } finally {
@@ -299,6 +319,7 @@ describe('Link Validator Service', () => {
                 const result = await validateLink('//this-domain-definitely-does-not-exist-12345.com', {
                     filesDir: tempDir,
                     timeout: 5000,
+                    lookupFn: publicLookup,
                 });
                 expect(result).toBe('Could not resolve host');
             } finally {
@@ -315,71 +336,123 @@ describe('Link Validator Service', () => {
         });
 
         it('should handle 301 redirects as valid', async () => {
-            // Mock fetch to return 301
-            const originalFetch = globalThis.fetch;
-            globalThis.fetch = async () =>
-                ({
-                    status: 301,
-                    ok: false,
-                }) as Response;
+            // A 301 with no Location header is returned by safeFetch as-is (not
+            // treated as a redirect to follow), so validateLink sees status 301.
+            // Inject fetchImpl + a public lookup to stay hermetic.
+            const fetchImpl = (async () => mockResponse({ status: 301, ok: false })) as unknown as typeof fetch;
 
-            try {
-                const result = await validateLink('https://example.com/redirect', {
-                    filesDir: tempDir,
-                    timeout: 5000,
-                });
-                expect(result).toBeNull(); // 301 is considered valid
-            } finally {
-                globalThis.fetch = originalFetch;
-            }
+            const result = await validateLink('https://example.com/redirect', {
+                filesDir: tempDir,
+                timeout: 5000,
+                lookupFn: publicLookup,
+                fetchImpl,
+            });
+            expect(result).toBeNull(); // 301 is considered valid
         });
 
         it('should fallback to GET with Range header when HEAD returns 405', async () => {
-            // Mock fetch to return 405 on HEAD, then 200 on GET
-            const originalFetch = globalThis.fetch;
+            // Mock fetch to return 405 on HEAD, then 200 on GET.
             let callCount = 0;
-            globalThis.fetch = async (url: string, options?: RequestInit) => {
+            const fetchImpl = (async (_url: string, options?: RequestInit) => {
                 callCount++;
                 if (options?.method === 'HEAD') {
-                    return { status: 405, ok: false } as Response;
+                    return mockResponse({ status: 405, ok: false });
                 }
                 // GET request with Range header
                 expect(options?.method).toBe('GET');
                 expect(options?.headers).toHaveProperty('Range', 'bytes=0-0');
-                return { status: 200, ok: true } as Response;
-            };
+                return mockResponse({ status: 200, ok: true });
+            }) as unknown as typeof fetch;
 
-            try {
-                const result = await validateLink('https://example.com/head-not-allowed', {
-                    filesDir: tempDir,
-                    timeout: 5000,
-                });
-                expect(result).toBeNull(); // Should be valid after GET fallback
-                expect(callCount).toBe(2); // HEAD then GET
-            } finally {
-                globalThis.fetch = originalFetch;
-            }
+            const result = await validateLink('https://example.com/head-not-allowed', {
+                filesDir: tempDir,
+                timeout: 5000,
+                lookupFn: publicLookup,
+                fetchImpl,
+            });
+            expect(result).toBeNull(); // Should be valid after GET fallback
+            expect(callCount).toBe(2); // HEAD then GET
         });
 
         it('should return error when GET fallback also fails', async () => {
-            // Mock fetch to return 405 on HEAD, then 404 on GET
-            const originalFetch = globalThis.fetch;
-            globalThis.fetch = async (_url: string, options?: RequestInit) => {
+            // Mock fetch to return 405 on HEAD, then 404 on GET.
+            const fetchImpl = (async (_url: string, options?: RequestInit) => {
                 if (options?.method === 'HEAD') {
-                    return { status: 405, ok: false } as Response;
+                    return mockResponse({ status: 405, ok: false });
                 }
-                return { status: 404, ok: false } as Response;
-            };
+                return mockResponse({ status: 404, ok: false });
+            }) as unknown as typeof fetch;
 
-            try {
-                const result = await validateLink('https://example.com/not-found', {
-                    filesDir: tempDir,
-                    timeout: 5000,
-                });
-                expect(result).toBe('404');
-            } finally {
-                globalThis.fetch = originalFetch;
-            }
+            const result = await validateLink('https://example.com/not-found', {
+                filesDir: tempDir,
+                timeout: 5000,
+                lookupFn: publicLookup,
+                fetchImpl,
+            });
+            expect(result).toBe('404');
+        });
+
+        it('should block a host that resolves to a private/loopback address (SSRF guard)', async () => {
+            // lookupFn maps the public-looking host to a loopback address. The
+            // guard must reject it before any fetch is attempted.
+            let fetchCalled = false;
+            const fetchImpl = (async () => {
+                fetchCalled = true;
+                return mockResponse({ status: 200, ok: true });
+            }) as unknown as typeof fetch;
+            const loopbackLookup: LookupFn = async () => [{ address: '127.0.0.1' }];
+
+            const result = await validateLink('https://internal.example.com/secret', {
+                filesDir: tempDir,
+                timeout: 5000,
+                lookupFn: loopbackLookup,
+                fetchImpl,
+            });
+
+            // Broken, not null — and a generic message that does not leak the IP.
+            expect(result).toBe('Blocked address');
+            expect(result).not.toContain('127.0.0.1');
+            expect(fetchCalled).toBe(false);
+        });
+
+        it('should block a cloud-metadata IP literal (169.254.169.254)', async () => {
+            // IP literal: the guard checks it directly without DNS.
+            let fetchCalled = false;
+            const fetchImpl = (async () => {
+                fetchCalled = true;
+                return mockResponse({ status: 200, ok: true });
+            }) as unknown as typeof fetch;
+
+            const result = await validateLink('http://169.254.169.254/latest/meta-data/', {
+                filesDir: tempDir,
+                timeout: 5000,
+                fetchImpl,
+            });
+
+            expect(result).toBe('Blocked address');
+            expect(fetchCalled).toBe(false);
+        });
+
+        it('should block a redirect from a public host to an internal host', async () => {
+            // First hop resolves public and returns a 302 to an internal host;
+            // safeFetch re-validates the next hop (resolved to loopback) and blocks.
+            const fetchImpl = (async () =>
+                mockResponse({
+                    status: 302,
+                    ok: false,
+                    location: 'http://internal.example.com/admin',
+                })) as unknown as typeof fetch;
+            const redirectLookup: LookupFn = async hostname =>
+                hostname === 'internal.example.com' ? [{ address: '127.0.0.1' }] : [{ address: '93.184.216.34' }];
+
+            const result = await validateLink('https://public.example.com/go', {
+                filesDir: tempDir,
+                timeout: 5000,
+                lookupFn: redirectLookup,
+                fetchImpl,
+            });
+
+            expect(result).toBe('Blocked address');
         });
     });
 

--- a/src/services/link-validator.ts
+++ b/src/services/link-validator.ts
@@ -8,6 +8,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
+import { safeFetch, SsrfBlockedError, type LookupFn } from '../utils/ssrf-guard';
 
 // =====================================================
 // Interfaces
@@ -170,6 +171,12 @@ export function extractLinksFromIdevices(idevices: IdeviceContent[]): ExtractedL
 export interface ValidateLinkOptions {
     filesDir: string;
     timeout?: number;
+    /** Maximum redirect hops to follow when validating external links (each re-validated). */
+    maxRedirects?: number;
+    /** Injectable DNS resolver, forwarded to the SSRF guard (for hermetic tests). */
+    lookupFn?: LookupFn;
+    /** Injectable fetch implementation, forwarded to the SSRF guard (for hermetic tests). */
+    fetchImpl?: typeof fetch;
 }
 
 /**
@@ -177,7 +184,7 @@ export interface ValidateLinkOptions {
  * Returns null if valid, or an error message if broken
  */
 export async function validateLink(url: string, options: ValidateLinkOptions): Promise<string | null> {
-    const { filesDir, timeout = 10000 } = options;
+    const { filesDir, timeout = 10000, maxRedirects, lookupFn, fetchImpl } = options;
 
     // Internal page links (exe-node:) - consider valid
     if (url.startsWith('exe-node:')) {
@@ -214,10 +221,16 @@ export async function validateLink(url: string, options: ValidateLinkOptions): P
         const timeoutId = setTimeout(() => controller.abort(), timeout);
 
         try {
-            let response = await fetch(normalizedUrl, {
+            // safeFetch enforces SSRF egress filtering (allow only http(s), reject
+            // private/loopback/link-local/CGNAT addresses) and follows redirects
+            // manually, re-validating every hop. It forces redirect: 'manual'
+            // internally, so we must NOT pass redirect: 'follow'.
+            let response = await safeFetch(normalizedUrl, {
                 method: 'HEAD',
                 signal: controller.signal,
-                redirect: 'follow',
+                maxRedirects,
+                lookupFn,
+                fetchImpl,
                 headers: {
                     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
                 },
@@ -229,10 +242,12 @@ export async function validateLink(url: string, options: ValidateLinkOptions): P
             if (response.status === 405) {
                 const controller2 = new AbortController();
                 const timeoutId2 = setTimeout(() => controller2.abort(), timeout);
-                response = await fetch(normalizedUrl, {
+                response = await safeFetch(normalizedUrl, {
                     method: 'GET',
                     signal: controller2.signal,
-                    redirect: 'follow',
+                    maxRedirects,
+                    lookupFn,
+                    fetchImpl,
                     headers: {
                         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
                         Range: 'bytes=0-0',
@@ -247,6 +262,12 @@ export async function validateLink(url: string, options: ValidateLinkOptions): P
             return String(response.status);
         } catch (fetchError: unknown) {
             clearTimeout(timeoutId);
+            // The SSRF guard blocked the URL or one of its redirect hops (private/
+            // loopback/link-local/CGNAT, disallowed scheme, etc.). Treat as broken
+            // without reflecting the resolved address (no internal-host oracle).
+            if (fetchError instanceof SsrfBlockedError) {
+                return 'Blocked address';
+            }
             const err = fetchError as { name?: string; message?: string; cause?: { code?: string } };
             if (err.name === 'AbortError') return 'Timeout';
             const cause = err.cause;

--- a/src/services/upload-session-manager.spec.ts
+++ b/src/services/upload-session-manager.spec.ts
@@ -1,9 +1,16 @@
 /**
  * Upload Session Manager Tests
  */
-import { describe, it, expect, beforeEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { SignJWT } from 'jose';
-import { createUploadSessionManager, MAX_BATCH_BYTES, MAX_BATCH_FILES } from './upload-session-manager';
+import {
+    createUploadSessionManager,
+    MAX_BATCH_BYTES,
+    MAX_BATCH_FILES,
+    CLEANUP_INTERVAL_MS,
+    startCleanupScheduler,
+    stopCleanupScheduler,
+} from './upload-session-manager';
 
 // Helper to get JWT secret as Uint8Array (for test token generation)
 const getJwtSecretEncoded = (): Uint8Array => {
@@ -346,6 +353,171 @@ describe('UploadSessionManager', () => {
             const cleaned = manager.cleanupExpired();
             expect(cleaned).toBe(0);
             expect(manager.getStats().activeSessions).toBe(1);
+        });
+
+        it('should free registered callbacks for expired sessions while keeping fresh ones', async () => {
+            // Expired session with a registered progress callback.
+            const { sessionToken: expiredToken } = await manager.createSession({
+                projectId: 'expired-project',
+                projectIdNum: 1,
+                userId: 1,
+                clientId: 'client-expired',
+                totalFiles: 5,
+                totalBytes: 1000,
+            });
+            const expiredPayload = await manager.validateSession(expiredToken);
+            let expiredCallbackCalled = false;
+            manager.onProgress(expiredPayload!.sessionId, () => {
+                expiredCallbackCalled = true;
+            });
+
+            // Fresh session that must survive cleanup with its callback intact.
+            const { sessionToken: freshToken } = await manager.createSession({
+                projectId: 'fresh-project',
+                projectIdNum: 2,
+                userId: 2,
+                clientId: 'client-fresh',
+                totalFiles: 5,
+                totalBytes: 1000,
+            });
+            const freshPayload = await manager.validateSession(freshToken);
+            let freshCallbackCalled = false;
+            manager.onProgress(freshPayload!.sessionId, () => {
+                freshCallbackCalled = true;
+            });
+
+            // Force the first session to be expired.
+            const expiredSession = manager.getSession(expiredPayload!.sessionId);
+            if (expiredSession) {
+                // @ts-expect-error - accessing private property for testing
+                expiredSession.expiresAt = Date.now() - 1000;
+            }
+
+            const cleaned = manager.cleanupExpired();
+            expect(cleaned).toBe(1);
+
+            // Expired session and its callback are gone: emitting must not fire it.
+            manager.emitProgress(expiredPayload!.sessionId, {
+                clientId: 'x',
+                bytesWritten: 0,
+                totalBytes: 0,
+                status: 'complete',
+            });
+            expect(expiredCallbackCalled).toBe(false);
+
+            // Fresh session and its callback are preserved.
+            expect(manager.getSession(freshPayload!.sessionId)).not.toBeNull();
+            manager.emitProgress(freshPayload!.sessionId, {
+                clientId: 'y',
+                bytesWritten: 100,
+                totalBytes: 1000,
+                status: 'writing',
+            });
+            expect(freshCallbackCalled).toBe(true);
+        });
+    });
+
+    describe('cleanup scheduler', () => {
+        afterEach(() => {
+            // Always stop the singleton scheduler so tests do not leak timers.
+            stopCleanupScheduler();
+        });
+
+        it('should expose a sane default interval (5 minutes)', () => {
+            expect(CLEANUP_INTERVAL_MS).toBe(5 * 60 * 1000);
+        });
+
+        it('should register one timer on start and clear it on stop', () => {
+            const realSetInterval = globalThis.setInterval;
+            const realClearInterval = globalThis.clearInterval;
+            let registered = 0;
+            let cleared = 0;
+
+            // @ts-expect-error - test override of global setInterval
+            globalThis.setInterval = (fn: () => void, ms?: number) => {
+                registered++;
+                return realSetInterval(fn, ms);
+            };
+            // @ts-expect-error - test override of global clearInterval
+            globalThis.clearInterval = (handle: ReturnType<typeof setInterval>) => {
+                cleared++;
+                return realClearInterval(handle);
+            };
+
+            try {
+                startCleanupScheduler(60000);
+                expect(registered).toBe(1);
+
+                stopCleanupScheduler();
+                expect(cleared).toBe(1);
+
+                // Calling stop again is a safe no-op (no extra clearInterval).
+                stopCleanupScheduler();
+                expect(cleared).toBe(1);
+            } finally {
+                globalThis.setInterval = realSetInterval;
+                globalThis.clearInterval = realClearInterval;
+            }
+        });
+
+        it('should replace an existing timer when started again (no leak)', () => {
+            const realSetInterval = globalThis.setInterval;
+            const realClearInterval = globalThis.clearInterval;
+            let registered = 0;
+            let cleared = 0;
+
+            // @ts-expect-error - test override of global setInterval
+            globalThis.setInterval = (fn: () => void, ms?: number) => {
+                registered++;
+                return realSetInterval(fn, ms);
+            };
+            // @ts-expect-error - test override of global clearInterval
+            globalThis.clearInterval = (handle: ReturnType<typeof setInterval>) => {
+                cleared++;
+                return realClearInterval(handle);
+            };
+
+            try {
+                startCleanupScheduler(60000);
+                startCleanupScheduler(60000);
+                // Second start must clear the first timer before registering the new one.
+                expect(registered).toBe(2);
+                expect(cleared).toBe(1);
+
+                stopCleanupScheduler();
+                expect(cleared).toBe(2);
+            } finally {
+                globalThis.setInterval = realSetInterval;
+                globalThis.clearInterval = realClearInterval;
+            }
+        });
+
+        it('should invoke cleanupExpired and cleanupStaleSlots on each scheduled pass', () => {
+            const realSetInterval = globalThis.setInterval;
+            const realClearInterval = globalThis.clearInterval;
+            let capturedCallback: (() => void) | null = null;
+
+            // Capture the scheduled callback without arming a real timer.
+            // @ts-expect-error - test override of global setInterval
+            globalThis.setInterval = (fn: () => void) => {
+                capturedCallback = fn;
+                return 0 as unknown as ReturnType<typeof setInterval>;
+            };
+            // @ts-expect-error - test override of global clearInterval
+            globalThis.clearInterval = () => {};
+
+            try {
+                startCleanupScheduler(60000);
+                expect(capturedCallback).not.toBeNull();
+
+                // Invoking the captured pass must not throw and must reclaim
+                // expired singleton sessions via cleanupExpired().
+                expect(() => capturedCallback!()).not.toThrow();
+            } finally {
+                globalThis.setInterval = realSetInterval;
+                globalThis.clearInterval = realClearInterval;
+                stopCleanupScheduler();
+            }
         });
     });
 

--- a/src/services/upload-session-manager.ts
+++ b/src/services/upload-session-manager.ts
@@ -13,6 +13,7 @@
  * 3. Receive real-time progress via WebSocket
  */
 import { SignJWT, jwtVerify, type JWTPayload } from 'jose';
+import { serverPriorityQueue } from './asset-priority-queue';
 
 /**
  * Upload session JWT payload
@@ -89,6 +90,9 @@ export const MAX_BATCH_BYTES = 100 * 1024 * 1024;
 
 // Maximum files per batch
 export const MAX_BATCH_FILES = 200;
+
+// Default interval for the periodic cleanup scheduler (5 minutes)
+export const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 
 /**
  * Factory function to create upload session manager with isolated state
@@ -347,3 +351,50 @@ export const emitBatchComplete = uploadSessionManager.emitBatchComplete;
 export const deleteSession = uploadSessionManager.deleteSession;
 export const cleanupExpired = uploadSessionManager.cleanupExpired;
 export const getStats = uploadSessionManager.getStats;
+
+// Module-level handle for the periodic cleanup scheduler.
+let cleanupScheduler: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the periodic cleanup scheduler for the default singleton manager.
+ *
+ * Without this, expired sessions and their registered progress/batch-complete
+ * callbacks accumulate in memory forever (the manager only stores state in
+ * in-memory Maps). The scheduler periodically reclaims expired sessions and
+ * also releases stale upload slots held by the asset priority queue.
+ *
+ * Idempotent: calling it again replaces any existing timer. The orchestrator
+ * (src/index.ts) is responsible for calling this at server boot.
+ *
+ * @param intervalMs - Interval between cleanup passes (default CLEANUP_INTERVAL_MS).
+ */
+export function startCleanupScheduler(intervalMs: number = CLEANUP_INTERVAL_MS): void {
+    // Replace any existing timer so repeated calls do not leak intervals.
+    if (cleanupScheduler) {
+        clearInterval(cleanupScheduler);
+        cleanupScheduler = null;
+    }
+
+    cleanupScheduler = setInterval(() => {
+        uploadSessionManager.cleanupExpired();
+        serverPriorityQueue.cleanupStaleSlots();
+    }, intervalMs);
+
+    // Do not keep the process alive solely for this timer (no-op in browsers).
+    if (typeof cleanupScheduler.unref === 'function') {
+        cleanupScheduler.unref();
+    }
+}
+
+/**
+ * Stop the periodic cleanup scheduler and clear its timer.
+ *
+ * Idempotent: safe to call when no scheduler is running. The orchestrator
+ * (src/index.ts) is responsible for calling this at server shutdown.
+ */
+export function stopCleanupScheduler(): void {
+    if (cleanupScheduler) {
+        clearInterval(cleanupScheduler);
+        cleanupScheduler = null;
+    }
+}

--- a/src/shared/export/exporters/Epub3Exporter.spec.ts
+++ b/src/shared/export/exporters/Epub3Exporter.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'bun:test';
+import { DOMParser as XmldomDOMParser } from '@xmldom/xmldom';
 import { Epub3Exporter } from './Epub3Exporter';
 import { zipSync, unzipSync, strToU8 } from 'fflate';
 import type {
@@ -1017,5 +1018,162 @@ describe('Icon Resolution via setThemeIconFiles', () => {
 
         const indexXhtml = zip.files.get('EPUB/index.xhtml') as string;
         expect(indexXhtml).toContain('theme/icons/activity.png');
+    });
+});
+
+describe('htmlToXhtml conversion (H11 corruption fixes)', () => {
+    let resources: MockResourceProvider;
+    let assets: MockAssetProvider;
+    let zip: MockZipProvider;
+
+    // Build a single-page project whose first-page content is fully controlled by the test.
+    function buildExporter(content: string): Epub3Exporter {
+        const pages: ExportPage[] = [
+            {
+                id: 'page-1',
+                title: 'Introduction',
+                parentId: null,
+                order: 0,
+                blocks: [
+                    {
+                        id: 'block-1',
+                        name: 'Content',
+                        order: 0,
+                        components: [
+                            {
+                                id: 'comp-1',
+                                type: 'FreeTextIdevice',
+                                order: 0,
+                                content,
+                            },
+                        ],
+                    },
+                ],
+            },
+            // Second page so that "chapter-1.html" is a real internal target the exporter generated.
+            {
+                id: 'page-2',
+                title: 'Chapter 1',
+                parentId: null,
+                order: 1,
+                blocks: [],
+            },
+        ];
+        const document = new MockDocument({}, pages);
+        return new Epub3Exporter(document, resources, assets, zip);
+    }
+
+    beforeEach(() => {
+        resources = new MockResourceProvider();
+        assets = new MockAssetProvider();
+        zip = new MockZipProvider();
+    });
+
+    it('(a) leaves external .html links unchanged', async () => {
+        const exporter = buildExporter('<p>See <a href="https://example.com/page.html">the page</a>.</p>');
+        await exporter.export();
+
+        const xhtml = zip.files.get('EPUB/index.xhtml') as string;
+        expect(xhtml).toContain('href="https://example.com/page.html"');
+        expect(xhtml).not.toContain('https://example.com/page.xhtml');
+    });
+
+    it('(a2) leaves external http and protocol-relative .html links unchanged', async () => {
+        const exporter = buildExporter(
+            '<p><a href="http://other.org/doc.html">a</a> <a href="//cdn.example/lib.html">b</a></p>',
+        );
+        await exporter.export();
+
+        const xhtml = zip.files.get('EPUB/index.xhtml') as string;
+        expect(xhtml).toContain('href="http://other.org/doc.html"');
+        // Protocol-relative URLs have no path scheme but their basename is not an internal page.
+        expect(xhtml).toContain('href="//cdn.example/lib.html"');
+    });
+
+    it('(b) does not mangle the literal text ".html" in prose', async () => {
+        const exporter = buildExporter(
+            '<p>To save your work, export it as an .html file or open page.html in a browser.</p>',
+        );
+        await exporter.export();
+
+        const xhtml = zip.files.get('EPUB/index.xhtml') as string;
+        expect(xhtml).toContain('export it as an .html file or open page.html in a browser');
+        expect(xhtml).not.toContain('.xhtml file');
+        expect(xhtml).not.toContain('page.xhtml in a browser');
+    });
+
+    it('(c) rewrites internal page links from .html to .xhtml', async () => {
+        const exporter = buildExporter(
+            '<p><a href="html/chapter-1.html">Chapter 1</a> and <a href="html/chapter-1.html#section">deep</a></p>',
+        );
+        await exporter.export();
+
+        const xhtml = zip.files.get('EPUB/index.xhtml') as string;
+        expect(xhtml).toContain('href="html/chapter-1.xhtml"');
+        expect(xhtml).toContain('href="html/chapter-1.xhtml#section"');
+        expect(xhtml).not.toContain('chapter-1.html');
+    });
+
+    it('(d) self-closes void elements without corrupting attributes containing ">"', async () => {
+        const exporter = buildExporter(
+            '<p>Line 1<br>Line 2</p>' +
+                '<hr>' +
+                '<img src="test.png" alt="An arrow -> pointer" title="a > b">' +
+                '<input type="text" value="x > y">',
+        );
+        await exporter.export();
+
+        const xhtml = zip.files.get('EPUB/index.xhtml') as string;
+
+        // Void elements are self-closed.
+        expect(xhtml).toMatch(/<br\s*\/>/);
+        expect(xhtml).toMatch(/<hr\s*\/>/);
+        expect(xhtml).toMatch(/<img[^>]*\/>/);
+        expect(xhtml).toMatch(/<input[^>]*\/>/);
+
+        // The ">" inside attribute values is escaped, not treated as the tag end.
+        expect(xhtml).toContain('alt="An arrow -&gt; pointer"');
+        expect(xhtml).toContain('title="a &gt; b"');
+        expect(xhtml).toContain('value="x &gt; y"');
+
+        // No mangled fragments leaked into the document body.
+        expect(xhtml).not.toContain('pointer"&gt;');
+    });
+
+    it('(d2) preserves script and style contents without escaping comparison operators', async () => {
+        const exporter = buildExporter(
+            '<div class="x">content</div>' +
+                '<script>if (a < b && c > d) { run(); }</script>' +
+                '<style>.foo > .bar { color: red; }</style>',
+        );
+        await exporter.export();
+
+        const xhtml = zip.files.get('EPUB/index.xhtml') as string;
+        expect(xhtml).toContain('if (a < b && c > d) { run(); }');
+        expect(xhtml).toContain('.foo > .bar { color: red; }');
+    });
+
+    it('produces well-formed XHTML parseable as XML', async () => {
+        const exporter = buildExporter(
+            '<p>Mixed <br>content<img src="x.png" alt="y > z"></p>' +
+                '<a href="https://example.com/page.html">ext</a>' +
+                '<a href="html/chapter-1.html">int</a>',
+        );
+        await exporter.export();
+
+        const xhtml = zip.files.get('EPUB/index.xhtml') as string;
+
+        // Re-parse the generated document strictly as XML; a fatalError would throw.
+        let parseError: string | null = null;
+        const doc = new XmldomDOMParser({
+            onError: (level: string, message: string) => {
+                if (level === 'fatalError') {
+                    parseError = message;
+                }
+            },
+        }).parseFromString(xhtml, 'text/xml');
+
+        expect(parseError).toBeNull();
+        expect(doc.getElementsByTagName('html').length).toBe(1);
     });
 });

--- a/src/shared/export/exporters/Epub3Exporter.ts
+++ b/src/shared/export/exporters/Epub3Exporter.ts
@@ -28,6 +28,7 @@ import { BaseExporter } from './BaseExporter';
 import { GlobalFontGenerator } from '../utils/GlobalFontGenerator';
 import { ODE_DTD_FILENAME, ODE_DTD_CONTENT } from '../constants';
 import { VOID_ELEMENTS } from '../../utils/html-constants';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 
 /**
  * EPUB3 XML namespaces
@@ -128,6 +129,11 @@ export class Epub3Exporter extends BaseExporter {
             // Build unique filename map for all pages (handles collisions)
             const pageFilenameMap = this.buildPageFilenameMap(pages);
 
+            // Set of internal page filenames (lowercased basenames) that the exporter itself
+            // generated. Used to rewrite ONLY internal .html links to .xhtml, never external
+            // URLs or prose text mentioning ".html".
+            const internalPageTargets = this.buildInternalPageTargets(pageFilenameMap);
+
             // 0. Pre-fetch theme to get the list of CSS/JS files for HTML includes and detect favicon
             const { themeFilesMap, themeRootFiles, faviconInfo } = await this.prepareThemeData(themeName);
 
@@ -160,6 +166,7 @@ export class Epub3Exporter extends BaseExporter {
                     themeRootFiles,
                     faviconInfo,
                     navLabels,
+                    internalPageTargets,
                 );
 
                 // Pre-render LaTeX ONLY if addMathJax is false
@@ -622,6 +629,7 @@ export class Epub3Exporter extends BaseExporter {
      * @param isIndex - Whether this is the index page
      * @param themeFiles - List of root-level theme CSS/JS files
      * @param faviconInfo - Favicon info for theme or default
+     * @param internalPageTargets - Set of internal page filenames (.html basenames) to rewrite to .xhtml
      */
     private generatePageXhtml(
         page: ExportPage,
@@ -632,6 +640,7 @@ export class Epub3Exporter extends BaseExporter {
         themeFiles?: string[],
         faviconInfo?: FaviconInfo | null,
         navLabels?: { license?: string },
+        internalPageTargets?: Set<string>,
     ): string {
         const lang = meta.language || 'en';
         const basePath = isIndex ? '' : '../';
@@ -691,67 +700,163 @@ export class Epub3Exporter extends BaseExporter {
         });
 
         // Convert HTML to XHTML
-        return this.htmlToXhtml(pageHtml, lang);
+        return this.htmlToXhtml(pageHtml, lang, internalPageTargets);
     }
 
     /**
-     * Convert HTML to XHTML
+     * Build the set of internal page filenames (lowercased `.html` basenames) that the
+     * exporter itself generated for this project.
+     *
+     * Only links resolving to one of these targets are rewritten from `.html` to `.xhtml`;
+     * external URLs and prose mentioning ".html" are never touched. The map stores the
+     * canonical `index.html` and `{sanitized-title}.html` filenames produced by
+     * {@link BaseExporter.buildPageFilenameMap}.
      */
-    private htmlToXhtml(html: string, lang: string): string {
-        let xhtml = html;
+    private buildInternalPageTargets(pageFilenameMap: Map<string, string>): Set<string> {
+        const targets = new Set<string>();
+        for (const filename of pageFilenameMap.values()) {
+            targets.add(filename.toLowerCase());
+        }
+        return targets;
+    }
 
-        // Add XML declaration if not present
-        if (!xhtml.startsWith('<?xml')) {
-            xhtml = `<?xml version="1.0" encoding="UTF-8"?>\n${xhtml}`;
+    /**
+     * Rewrite an internal page link attribute (`href`/`src`) from `.html` to `.xhtml`.
+     *
+     * Only rewrites when the attribute resolves to a known internal page filename
+     * (from {@link buildInternalPageTargets}). Leaves external URLs (any value with a
+     * URI scheme such as `http:`, `https:`, `mailto:`, `data:`) and non-page links
+     * untouched. Preserves any `?query` and `#fragment` suffixes.
+     */
+    private rewriteInternalLinkAttribute(value: string, internalPageTargets: Set<string>): string {
+        // Split off fragment (#...) and query (?...) — these may legitimately contain ".html".
+        const hashIndex = value.indexOf('#');
+        const fragment = hashIndex !== -1 ? value.slice(hashIndex) : '';
+        const beforeHash = hashIndex !== -1 ? value.slice(0, hashIndex) : value;
+
+        const queryIndex = beforeHash.indexOf('?');
+        const query = queryIndex !== -1 ? beforeHash.slice(queryIndex) : '';
+        const pathPart = queryIndex !== -1 ? beforeHash.slice(0, queryIndex) : beforeHash;
+
+        // Never rewrite values that carry a URI scheme (external/absolute links).
+        if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(pathPart)) {
+            return value;
+        }
+        if (!pathPart.toLowerCase().endsWith('.html')) {
+            return value;
         }
 
-        // Add DOCTYPE if not present
-        if (!xhtml.includes('<!DOCTYPE')) {
-            xhtml = xhtml.replace(
+        // Only rewrite links whose basename is a page the exporter generated.
+        const basename = pathPart.split('/').pop() || '';
+        if (!internalPageTargets.has(basename.toLowerCase())) {
+            return value;
+        }
+
+        const newPath = `${pathPart.slice(0, -'.html'.length)}.xhtml`;
+        return `${newPath}${query}${fragment}`;
+    }
+
+    /**
+     * Convert HTML to XHTML for EPUB3.
+     *
+     * Parses the page with `@xmldom/xmldom` (the cross-runtime DOM implementation already
+     * used by the import pipeline; works in both the browser and Bun) and re-serializes it
+     * as XHTML. This correctly self-closes void elements even when their attributes contain
+     * `>` (e.g. `<input value="a > b">`), escapes attribute values, and preserves
+     * `<script>`/`<style>` contents without mangling.
+     *
+     * Internal page links (`.html` references the exporter generated) are rewritten to
+     * `.xhtml` on the parsed DOM, so external URLs and prose mentioning ".html" are never
+     * altered.
+     *
+     * If the document cannot be parsed (only on truly malformed, non-recoverable input),
+     * falls back to a conservative regex-based conversion that still scopes link rewriting
+     * to internal targets.
+     */
+    private htmlToXhtml(html: string, lang: string, internalPageTargets?: Set<string>): string {
+        const targets = internalPageTargets ?? new Set<string>();
+
+        // Normalize the document head: ensure the XML declaration, DOCTYPE, and XHTML
+        // namespace are present and the html element carries a single lang/xml:lang pair.
+        let prepared = html;
+        if (!prepared.startsWith('<?xml')) {
+            prepared = `<?xml version="1.0" encoding="UTF-8"?>\n${prepared}`;
+        }
+        if (!prepared.includes('<!DOCTYPE')) {
+            prepared = prepared.replace(
                 '<?xml version="1.0" encoding="UTF-8"?>',
                 '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE html>',
             );
         }
-
-        // Add XHTML namespace to html element
-        // First, remove any existing lang/xml:lang attributes to avoid duplication
-        xhtml = xhtml.replace(/<html([^>]*)>/i, (match, attrs) => {
-            // Remove existing lang and xml:lang attributes
+        prepared = prepared.replace(/<html([^>]*)>/i, (_match, attrs) => {
             const cleanAttrs = attrs
                 .replace(/\s+xml:lang=["'][^"']*["']/gi, '')
                 .replace(/\s+lang=["'][^"']*["']/gi, '');
             return `<html xmlns="${EPUB3_NAMESPACES.XHTML}" xml:lang="${lang}" lang="${lang}"${cleanAttrs}>`;
         });
 
-        // Self-close void elements (use word boundary \b to avoid matching substrings like col matching colgroup)
-        for (const element of VOID_ELEMENTS) {
-            // Match <element ...> (without closing slash) - word boundary ensures exact element match
-            const regex = new RegExp(`<(${element})\\b([^>]*[^/])>`, 'gi');
-            xhtml = xhtml.replace(regex, '<$1$2/>');
+        try {
+            // Parse leniently: recover from non-fatal HTML quirks (unescaped ampersands,
+            // unquoted attributes) but rethrow genuinely unrecoverable input so we can fall
+            // back. The onError handler suppresses noisy warning/error logging.
+            const parser = new DOMParser({
+                onError: (level, message) => {
+                    if (level === 'fatalError') {
+                        throw new Error(message);
+                    }
+                },
+            });
+            const doc = parser.parseFromString(prepared, 'text/html');
 
-            // Also handle <element> (no attributes)
-            const simpleRegex = new RegExp(`<(${element})>`, 'gi');
-            xhtml = xhtml.replace(simpleRegex, '<$1/>');
+            // Rewrite internal .html links to .xhtml on the DOM (href + src attributes).
+            for (const element of Array.from(doc.getElementsByTagName('*'))) {
+                for (const attr of ['href', 'src']) {
+                    const value = element.getAttribute(attr);
+                    if (value) {
+                        const rewritten = this.rewriteInternalLinkAttribute(value, targets);
+                        if (rewritten !== value) {
+                            element.setAttribute(attr, rewritten);
+                        }
+                    }
+                }
+            }
+
+            let xhtml = new XMLSerializer().serializeToString(doc);
+
+            // The serializer keeps empty style attributes; drop them for cleanliness.
+            xhtml = xhtml.replace(/\s+style=["']\s*["']/g, '');
+
+            return xhtml;
+        } catch {
+            // Conservative fallback for non-recoverable input: never touch external URLs or
+            // prose, and only rewrite internal links via the same scoped helper.
+            return this.htmlToXhtmlFallback(prepared, targets);
         }
+    }
 
-        // Escape unescaped ampersands in attribute values (for URLs with query params like &download=false)
-        // Match & not followed by a valid entity name and semicolon
-        xhtml = xhtml.replace(/&(?!(?:amp|lt|gt|quot|apos|nbsp|#\d+|#x[0-9a-fA-F]+);)/g, '&amp;');
+    /**
+     * Conservative regex-based HTML→XHTML conversion used only when DOM parsing fails on
+     * unrecoverable input. Self-closes void elements (tolerating quoted attributes that
+     * contain `>`) and rewrites only internal page links.
+     */
+    private htmlToXhtmlFallback(html: string, internalPageTargets: Set<string>): string {
+        let xhtml = html;
 
-        // Fix unquoted boolean attributes like scorm=false → scorm="false"
-        // Match attribute=value where value has no quotes and is alphanumeric
-        xhtml = xhtml.replace(/(\s)([a-zA-Z][a-zA-Z0-9-]*)=(true|false|[a-zA-Z0-9_-]+)(?=[\s>/])/g, '$1$2="$3"');
+        // Self-close void elements, scanning attributes safely so a `>` inside a quoted
+        // attribute value does not prematurely end the tag.
+        const voidPattern = new RegExp(`<(${VOID_ELEMENTS.join('|')})\\b((?:"[^"]*"|'[^']*'|[^>"'])*?)\\s*/?>`, 'gi');
+        xhtml = xhtml.replace(voidPattern, (_match, tag, attrs) => `<${tag}${attrs.replace(/\s+$/, '')} />`);
 
-        // Fix malformed attributes like class=""value> → class="value">
-        // This handles case where opening has double-quote and closing quote is missing before >
-        // Exclude /> to avoid breaking self-closed void elements like alt=""/>
-        xhtml = xhtml.replace(/(\s[a-zA-Z][a-zA-Z0-9-]*)=""([^"<>/]+)>/g, '$1="$2">');
+        // Rewrite only internal page links (href/src) from .html to .xhtml.
+        const linkPattern = /\b(href|src)=("([^"]*)"|'([^']*)')/gi;
+        xhtml = xhtml.replace(linkPattern, (match, attr, _quoted, dq, sq) => {
+            const quote = dq !== undefined ? '"' : "'";
+            const value = dq !== undefined ? dq : sq;
+            const rewritten = this.rewriteInternalLinkAttribute(value, internalPageTargets);
+            return rewritten === value ? match : `${attr}=${quote}${rewritten}${quote}`;
+        });
 
-        // Convert .html references to .xhtml
-        xhtml = xhtml.replace(/\.html(['"#\s])/g, '.xhtml$1');
-        xhtml = xhtml.replace(/\.html$/g, '.xhtml');
-
-        // Remove empty style attributes
+        // Remove empty style attributes.
         xhtml = xhtml.replace(/\s+style=["']\s*["']/g, '');
 
         return xhtml;

--- a/src/shared/import/ElpxImporter.spec.ts
+++ b/src/shared/import/ElpxImporter.spec.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { existsSync, mkdirSync, rmSync } from 'fs';
 
-import { ElpxImporter } from './ElpxImporter';
+import { ElpxImporter, ZipLimitError, DEFAULT_ZIP_LIMITS } from './ElpxImporter';
 import { FileSystemAssetHandler } from './FileSystemAssetHandler';
 import type { Logger } from './interfaces';
 
@@ -510,6 +510,173 @@ describe('ElpxImporter', () => {
             await expect(importer.importFromBuffer(emptyZip)).rejects.toThrow(
                 'Unable to open this file: content.xml is missing',
             );
+
+            ydoc.destroy();
+        });
+    });
+
+    describe('ZIP-bomb decompression limits', () => {
+        // Build a valid eXeLearning archive (content.xml + a controllable payload entry)
+        // so we exercise the real importer decode path, not a generic failure.
+        const minimalContentXml = '<?xml version="1.0" encoding="UTF-8"?><odeProperties></odeProperties>';
+
+        it('exposes generous, overridable defaults above realistic .elp sizes', () => {
+            // Largest shipped fixtures decompress to ~42 MB / ~1440 entries / ~3.4 MB max entry.
+            // Defaults must comfortably exceed those so legitimate imports never trip the guard.
+            expect(DEFAULT_ZIP_LIMITS.maxTotalBytes).toBeGreaterThanOrEqual(100 * 1024 * 1024);
+            expect(DEFAULT_ZIP_LIMITS.maxEntryBytes).toBeGreaterThanOrEqual(50 * 1024 * 1024);
+            expect(DEFAULT_ZIP_LIMITS.maxEntries).toBeGreaterThanOrEqual(2000);
+        });
+
+        it('rejects a per-entry decompression bomb without inflating it', async () => {
+            const fflate = await import('fflate');
+
+            // 200 MB of zeros compresses to ~200 KB (a ~1000:1 bomb). With a 5 MB
+            // per-entry cap the importer must refuse it BEFORE inflation. fflate
+            // reads originalSize from the central directory in the filter callback,
+            // so the 200 MB is never materialised.
+            const bombPayload = new Uint8Array(200 * 1024 * 1024);
+            const zip = fflate.zipSync(
+                {
+                    'content.xml': new TextEncoder().encode(minimalContentXml),
+                    'bomb.bin': bombPayload,
+                },
+                { level: 6 },
+            );
+            // Sanity: the crafted archive really is tiny on disk (the DoS vector).
+            expect(zip.length).toBeLessThan(2 * 1024 * 1024);
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger, {
+                maxEntryBytes: 5 * 1024 * 1024,
+            });
+
+            await expect(importer.importFromBuffer(zip)).rejects.toThrow(ZipLimitError);
+            await expect(importer.importFromBuffer(zip)).rejects.toThrow(/too large when decompressed/);
+
+            ydoc.destroy();
+        });
+
+        it('rejects when the cumulative decompressed size exceeds the cap', async () => {
+            const fflate = await import('fflate');
+
+            // Several individually-acceptable entries that together blow the total cap.
+            const chunk = new Uint8Array(2 * 1024 * 1024); // 2 MB each (compresses small)
+            const entries: Record<string, Uint8Array> = {
+                'content.xml': new TextEncoder().encode(minimalContentXml),
+            };
+            for (let i = 0; i < 10; i++) {
+                entries[`pad-${i}.bin`] = chunk;
+            }
+            const zip = fflate.zipSync(entries, { level: 6 });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger, {
+                maxEntryBytes: 5 * 1024 * 1024, // each entry passes
+                maxTotalBytes: 8 * 1024 * 1024, // but the sum does not
+            });
+
+            await expect(importer.importFromBuffer(zip)).rejects.toThrow(ZipLimitError);
+            await expect(importer.importFromBuffer(zip)).rejects.toThrow(/maximum total decompressed size/);
+
+            ydoc.destroy();
+        });
+
+        it('rejects when the archive exceeds the maximum entry count', async () => {
+            const fflate = await import('fflate');
+
+            const entries: Record<string, Uint8Array> = {
+                'content.xml': new TextEncoder().encode(minimalContentXml),
+            };
+            for (let i = 0; i < 20; i++) {
+                entries[`tiny-${i}.txt`] = new Uint8Array([0]);
+            }
+            const zip = fflate.zipSync(entries, { level: 6 });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger, {
+                maxEntries: 5,
+            });
+
+            await expect(importer.importFromBuffer(zip)).rejects.toThrow(ZipLimitError);
+            await expect(importer.importFromBuffer(zip)).rejects.toThrow(/maximum allowed number of entries/);
+
+            ydoc.destroy();
+        });
+
+        it('applies the same guard to the nested-ELP decompression path', async () => {
+            const fflate = await import('fflate');
+
+            // Inner ELP carries the bomb; the outer ZIP wraps it as a single .elp entry,
+            // exercising the nested-ELP branch in importFromBuffer.
+            const innerBomb = fflate.zipSync(
+                {
+                    'content.xml': new TextEncoder().encode(minimalContentXml),
+                    'bomb.bin': new Uint8Array(200 * 1024 * 1024),
+                },
+                { level: 6 },
+            );
+            const outerZip = fflate.zipSync({ 'project.elp': innerBomb }, { level: 6 });
+            expect(outerZip.length).toBeLessThan(2 * 1024 * 1024);
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger, {
+                maxEntryBytes: 5 * 1024 * 1024,
+            });
+
+            await expect(importer.importFromBuffer(outerZip)).rejects.toThrow(ZipLimitError);
+            await expect(importer.importFromBuffer(outerZip)).rejects.toThrow(/nested ELP file/);
+
+            ydoc.destroy();
+        });
+
+        it('rejects oversized pre-extracted contents in importFromZipContents', async () => {
+            const zipContents: Record<string, Uint8Array> = {
+                'content.xml': new TextEncoder().encode(minimalContentXml),
+                'huge.bin': new Uint8Array(8 * 1024 * 1024),
+            };
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger, {
+                maxEntryBytes: 4 * 1024 * 1024,
+            });
+
+            await expect(importer.importFromZipContents(zipContents)).rejects.toThrow(ZipLimitError);
+
+            ydoc.destroy();
+        });
+
+        it('still imports a normal small ELP under default limits', async () => {
+            const elpPath = path.join(process.cwd(), 'test/fixtures/basic-example.elp');
+            const elpBuffer = await fs.readFile(elpPath);
+
+            const ydoc = new Y.Doc();
+            // Default limits (no override) — the legitimate fixture must import cleanly.
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+
+            const result = await importer.importFromBuffer(new Uint8Array(elpBuffer));
+            expect(result.pages).toBeGreaterThan(0);
+            expect(result.components).toBeGreaterThan(0);
+
+            ydoc.destroy();
+        });
+
+        it('lets a generous custom cap admit a legitimately large fixture', async () => {
+            // todos-los-idevices.elp decompresses to ~42 MB / ~1437 entries. With caps
+            // set just above those real figures it must still import, proving the guard
+            // does not penalise large-but-legitimate packages.
+            const elpPath = path.join(process.cwd(), 'test/fixtures/todos-los-idevices.elp');
+            const elpBuffer = await fs.readFile(elpPath);
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger, {
+                maxTotalBytes: 100 * 1024 * 1024,
+                maxEntryBytes: 20 * 1024 * 1024,
+                maxEntries: 5000,
+            });
+
+            const result = await importer.importFromBuffer(new Uint8Array(elpBuffer));
+            expect(result.pages).toBeGreaterThan(0);
 
             ydoc.destroy();
         });

--- a/src/shared/import/ElpxImporter.ts
+++ b/src/shared/import/ElpxImporter.ts
@@ -53,6 +53,51 @@ import type { LegacyParseResult, LegacyPage, LegacyBlock, LegacyIdevice, LegacyM
 import { generateOdeId } from '../export/utils/odeId';
 
 /**
+ * Decompression safety limits (ZIP-bomb / DoS protection).
+ *
+ * DEFLATE achieves ratios near 1000:1 on repetitive data, so a tiny upload can
+ * expand to tens of GB and OOM the shared server. `fflate.unzipSync` returns
+ * every entry fully decompressed in memory, so we MUST refuse oversized entries
+ * BEFORE they are inflated.
+ *
+ * fflate exposes each entry's `originalSize` (the uncompressed size recorded in
+ * the ZIP central directory) to the `filter` callback, and that callback runs
+ * *before* the entry is decompressed. We use it to enforce three independent
+ * caps and abort by throwing — guaranteeing we never inflate beyond the cap.
+ *
+ * Defaults are conservative but comfortably above real .elp files: the largest
+ * shipped fixtures (`todos-los-idevices.elp`, `Manual de eXeLearning 3.0.elpx`)
+ * decompress to ~42 MB across ~1440 entries, with a largest single entry of
+ * ~3.4 MB. The limits below leave ample headroom for legitimate packages.
+ */
+export interface ZipDecompressionLimits {
+    /** Maximum total uncompressed bytes across all entries. */
+    maxTotalBytes: number;
+    /** Maximum uncompressed bytes for any single entry. */
+    maxEntryBytes: number;
+    /** Maximum number of entries in the archive. */
+    maxEntries: number;
+}
+
+/** Default ZIP decompression limits applied to every inflate path. */
+export const DEFAULT_ZIP_LIMITS: ZipDecompressionLimits = {
+    maxTotalBytes: 500 * 1024 * 1024, // 500 MB cumulative
+    maxEntryBytes: 200 * 1024 * 1024, // 200 MB per entry
+    maxEntries: 10000, // entry-count cap
+};
+
+/**
+ * Thrown when a ZIP archive would exceed the configured decompression limits.
+ * The inflate is aborted before the offending data is materialised in memory.
+ */
+export class ZipLimitError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ZipLimitError';
+    }
+}
+
+/**
  * ElpxImporter class
  * Imports ELP/ELPX files into a Yjs document
  */
@@ -62,17 +107,110 @@ export class ElpxImporter {
     private assetMap: Map<string, string> = new Map();
     private onProgress: ((progress: ImportProgress) => void) | null = null;
     private logger: Logger;
+    private zipLimits: ZipDecompressionLimits;
 
     /**
      * Create a new ElpxImporter
      * @param ydoc - Yjs document to populate
      * @param assetHandler - Asset handler for storing assets (optional)
      * @param logger - Logger for debug output (optional)
+     * @param zipLimits - ZIP-bomb decompression limits (optional, sensible defaults)
      */
-    constructor(ydoc: Y.Doc, assetHandler: AssetHandler | null = null, logger: Logger = defaultLogger) {
+    constructor(
+        ydoc: Y.Doc,
+        assetHandler: AssetHandler | null = null,
+        logger: Logger = defaultLogger,
+        zipLimits: Partial<ZipDecompressionLimits> = {},
+    ) {
         this.ydoc = ydoc;
         this.assetHandler = assetHandler;
         this.logger = logger;
+        this.zipLimits = { ...DEFAULT_ZIP_LIMITS, ...zipLimits };
+    }
+
+    /**
+     * Decompress a ZIP buffer with hard limits enforced BEFORE inflation.
+     *
+     * fflate's `filter` callback receives each entry's `originalSize` (read from
+     * the ZIP central directory) and runs before that entry is decompressed.
+     * We use it to reject the archive the moment a per-entry, cumulative, or
+     * entry-count cap would be exceeded, throwing {@link ZipLimitError}. This
+     * guarantees the offending bytes are never materialised in memory, so a
+     * zip bomb cannot OOM the process.
+     *
+     * @param buffer - Raw ZIP bytes
+     * @param label - Human-readable archive label for error messages
+     * @returns Map of entry path -> decompressed bytes
+     */
+    private safeUnzip(buffer: Uint8Array, label: string): Record<string, Uint8Array> {
+        const { maxTotalBytes, maxEntryBytes, maxEntries } = this.zipLimits;
+        let cumulativeBytes = 0;
+        let entryCount = 0;
+
+        return fflate.unzipSync(buffer, {
+            filter: (file: { name: string; originalSize: number }) => {
+                entryCount++;
+                if (entryCount > maxEntries) {
+                    throw new ZipLimitError(`${label} exceeds the maximum allowed number of entries (${maxEntries}).`);
+                }
+
+                const entrySize = file.originalSize;
+                if (entrySize > maxEntryBytes) {
+                    throw new ZipLimitError(
+                        `Entry '${file.name}' in ${label} is too large when decompressed ` +
+                            `(${entrySize} bytes > ${maxEntryBytes} byte limit).`,
+                    );
+                }
+
+                cumulativeBytes += entrySize;
+                if (cumulativeBytes > maxTotalBytes) {
+                    throw new ZipLimitError(
+                        `${label} exceeds the maximum total decompressed size ` +
+                            `(${cumulativeBytes} bytes > ${maxTotalBytes} byte limit).`,
+                    );
+                }
+
+                return true;
+            },
+        });
+    }
+
+    /**
+     * Validate an already-decompressed entry map against the same limits as
+     * {@link safeUnzip}. Used by `importFromZipContents`, whose caller provides
+     * the contents already inflated: we cannot prevent the original inflation,
+     * but we refuse to keep processing (asset writes, Y.Doc population) an
+     * archive whose materialised payload exceeds the configured caps, so the
+     * server-side path stays bounded.
+     *
+     * @param zipContents - Already-extracted entry map
+     * @param label - Human-readable archive label for error messages
+     */
+    private assertZipContentsWithinLimits(zipContents: Record<string, Uint8Array>, label: string): void {
+        const { maxTotalBytes, maxEntryBytes, maxEntries } = this.zipLimits;
+        const entries = Object.entries(zipContents);
+
+        if (entries.length > maxEntries) {
+            throw new ZipLimitError(`${label} exceeds the maximum allowed number of entries (${maxEntries}).`);
+        }
+
+        let cumulativeBytes = 0;
+        for (const [name, data] of entries) {
+            const entrySize = data.length;
+            if (entrySize > maxEntryBytes) {
+                throw new ZipLimitError(
+                    `Entry '${name}' in ${label} is too large when decompressed ` +
+                        `(${entrySize} bytes > ${maxEntryBytes} byte limit).`,
+                );
+            }
+            cumulativeBytes += entrySize;
+            if (cumulativeBytes > maxTotalBytes) {
+                throw new ZipLimitError(
+                    `${label} exceeds the maximum total decompressed size ` +
+                        `(${cumulativeBytes} bytes > ${maxTotalBytes} byte limit).`,
+                );
+            }
+        }
     }
 
     // =========================================================================
@@ -171,8 +309,8 @@ export class ElpxImporter {
         // Phase 1: Decompressing (0-10%)
         this.reportProgress('decompress', 0, 'Decompressing...');
 
-        // Decompress ZIP
-        const zip = fflate.unzipSync(buffer);
+        // Decompress ZIP with hard limits enforced before inflation (ZIP-bomb guard)
+        const zip = this.safeUnzip(buffer, 'ELP/ELPX archive');
 
         // Report decompression complete (10%)
         this.reportProgress('decompress', 10, 'File decompressed');
@@ -191,7 +329,8 @@ export class ElpxImporter {
             if (elpFiles.length === 1) {
                 this.logger.log(`[ElpxImporter] Found nested ELP file: ${elpFiles[0]}, extracting...`);
                 const nestedElpData = workingZip[elpFiles[0]];
-                workingZip = fflate.unzipSync(nestedElpData);
+                // Apply the same ZIP-bomb guard to the nested-ELP decompression path.
+                workingZip = this.safeUnzip(nestedElpData, `nested ELP file '${elpFiles[0]}'`);
             } else if (elpFiles.length > 1) {
                 throw new Error('ZIP contains multiple ELP files. Please extract and open one at a time.');
             }
@@ -285,6 +424,10 @@ export class ElpxImporter {
         }
 
         this.logger.log('[ElpxImporter] Starting import from zip contents');
+
+        // Enforce the same decompression caps on the pre-extracted payload so the
+        // server-side path cannot be driven to OOM with an oversized entry map.
+        this.assertZipContentsWithinLimits(zipContents, 'extracted ELP contents');
 
         // Skip decompression phase since contents are already extracted
         this.reportProgress('decompress', 10, 'Files ready');

--- a/src/shared/import/LegacyXmlParser.spec.ts
+++ b/src/shared/import/LegacyXmlParser.spec.ts
@@ -1585,4 +1585,340 @@ describe('LegacyXmlParser', () => {
             expect(page!.blocks[0].name).toBe('');
         });
     });
+
+    describe('instance-by-reference resolution (H13 O(N^2) fix)', () => {
+        it('resolves a <reference key="..."/> iDevice to the originally declared instance', () => {
+            // The FreeTextIdevice (reference="3") is declared inline on the first page and
+            // re-used on the second page through a <reference key="3"/> placeholder.
+            // The referenced instance must resolve to the same iDevice content.
+            const legacyXml = `<?xml version="1.0" encoding="utf-8"?>
+<instance class="exe.engine.package.Package" reference="1">
+  <dictionary>
+    <string role="key" value="_title"/>
+    <unicode value="Project"/>
+    <string role="key" value="_root"/>
+    <instance class="exe.engine.node.Node" reference="2">
+      <dictionary>
+        <string role="key" value="_title"/>
+        <unicode value="Root"/>
+        <string role="key" value="parent"/>
+        <none/>
+        <string role="key" value="children"/>
+        <list>
+          <instance class="exe.engine.node.Node" reference="20">
+            <dictionary>
+              <string role="key" value="_title"/>
+              <unicode value="Page With Inline iDevice"/>
+              <string role="key" value="parent"/>
+              <reference key="2"/>
+              <string role="key" value="idevices"/>
+              <list>
+                <instance class="exe.engine.freetextidevice.FreeTextIdevice" reference="3">
+                  <dictionary>
+                    <string role="key" value="fields"/>
+                    <list>
+                      <instance class="exe.engine.field.TextAreaField" reference="4">
+                        <dictionary>
+                          <string role="key" value="content_w_resourcePaths"/>
+                          <unicode value="&lt;p&gt;Shared iDevice Content&lt;/p&gt;"/>
+                        </dictionary>
+                      </instance>
+                    </list>
+                  </dictionary>
+                </instance>
+              </list>
+              <string role="key" value="children"/>
+              <list/>
+            </dictionary>
+          </instance>
+          <instance class="exe.engine.node.Node" reference="21">
+            <dictionary>
+              <string role="key" value="_title"/>
+              <unicode value="Page With Referenced iDevice"/>
+              <string role="key" value="parent"/>
+              <reference key="2"/>
+              <string role="key" value="idevices"/>
+              <list>
+                <reference key="3"/>
+              </list>
+              <string role="key" value="children"/>
+              <list/>
+            </dictionary>
+          </instance>
+        </list>
+        <string role="key" value="idevices"/>
+        <list/>
+      </dictionary>
+    </instance>
+  </dictionary>
+</instance>`;
+
+            const result = parser.parse(legacyXml);
+
+            const inlinePage = result.pages.find(p => p.title === 'Page With Inline iDevice');
+            const referencedPage = result.pages.find(p => p.title === 'Page With Referenced iDevice');
+
+            expect(inlinePage).toBeDefined();
+            expect(referencedPage).toBeDefined();
+
+            // The inline page owns the real iDevice with its content.
+            const inlineHtml = inlinePage!.blocks[0].idevices[0].htmlView;
+            expect(inlineHtml).toContain('Shared iDevice Content');
+
+            // The referenced page must resolve <reference key="3"/> to the SAME instance,
+            // producing identical iDevice content (first-match semantics preserved).
+            expect(referencedPage!.blocks.length).toBeGreaterThan(0);
+            const referencedHtml = referencedPage!.blocks[0].idevices[0].htmlView;
+            expect(referencedHtml).toContain('Shared iDevice Content');
+            expect(referencedHtml).toBe(inlineHtml);
+        });
+
+        it('resolves field-level <reference key="..."/> to the first matching instance', () => {
+            // A TextAreaField (reference="100") is declared inline in the first iDevice's
+            // fields list and re-used via <reference key="100"/> in the second iDevice.
+            const legacyXml = `<?xml version="1.0" encoding="utf-8"?>
+<instance class="exe.engine.package.Package" reference="1">
+  <dictionary>
+    <string role="key" value="_title"/>
+    <unicode value="Project"/>
+    <string role="key" value="_root"/>
+    <instance class="exe.engine.node.Node" reference="2">
+      <dictionary>
+        <string role="key" value="_title"/>
+        <unicode value="Root"/>
+        <string role="key" value="parent"/>
+        <none/>
+        <string role="key" value="idevices"/>
+        <list>
+          <instance class="exe.engine.freetextidevice.FreeTextIdevice" reference="10">
+            <dictionary>
+              <string role="key" value="fields"/>
+              <list>
+                <instance class="exe.engine.field.TextAreaField" reference="100">
+                  <dictionary>
+                    <string role="key" value="content_w_resourcePaths"/>
+                    <unicode value="&lt;p&gt;Reused Field Content&lt;/p&gt;"/>
+                  </dictionary>
+                </instance>
+              </list>
+            </dictionary>
+          </instance>
+          <instance class="exe.engine.freetextidevice.FreeTextIdevice" reference="11">
+            <dictionary>
+              <string role="key" value="fields"/>
+              <list>
+                <reference key="100"/>
+              </list>
+            </dictionary>
+          </instance>
+        </list>
+      </dictionary>
+    </instance>
+  </dictionary>
+</instance>`;
+
+            const result = parser.parse(legacyXml);
+            const page = result.pages.find(p => p.title === 'Root');
+            expect(page).toBeDefined();
+
+            const ideviceHtmls = page!.blocks.flatMap(b => b.idevices.map(d => d.htmlView));
+            const matching = ideviceHtmls.filter(html => html.includes('Reused Field Content'));
+            // Both the inline and the referenced iDevice must carry the same field content.
+            expect(matching.length).toBe(2);
+        });
+
+        it('leaves output unchanged when a reference points to a missing instance', () => {
+            // <reference key="999"/> has no matching instance; it must be skipped silently
+            // (mirrors the previous [0]-on-empty-array undefined behavior).
+            const legacyXml = `<?xml version="1.0" encoding="utf-8"?>
+<instance class="exe.engine.package.Package" reference="1">
+  <dictionary>
+    <string role="key" value="_title"/>
+    <unicode value="Project"/>
+    <string role="key" value="_root"/>
+    <instance class="exe.engine.node.Node" reference="2">
+      <dictionary>
+        <string role="key" value="_title"/>
+        <unicode value="Root"/>
+        <string role="key" value="parent"/>
+        <none/>
+        <string role="key" value="idevices"/>
+        <list>
+          <reference key="999"/>
+          <instance class="exe.engine.freetextidevice.FreeTextIdevice" reference="3">
+            <dictionary>
+              <string role="key" value="fields"/>
+              <list>
+                <instance class="exe.engine.field.TextAreaField" reference="4">
+                  <dictionary>
+                    <string role="key" value="content_w_resourcePaths"/>
+                    <unicode value="&lt;p&gt;Present iDevice&lt;/p&gt;"/>
+                  </dictionary>
+                </instance>
+              </list>
+            </dictionary>
+          </instance>
+        </list>
+      </dictionary>
+    </instance>
+  </dictionary>
+</instance>`;
+
+            const result = parser.parse(legacyXml);
+            const page = result.pages.find(p => p.title === 'Root');
+            expect(page).toBeDefined();
+
+            const ideviceHtmls = page!.blocks.flatMap(b => b.idevices.map(d => d.htmlView));
+            // Only the real iDevice survives; the dangling reference is dropped.
+            expect(ideviceHtmls.some(html => html.includes('Present iDevice'))).toBe(true);
+            expect(ideviceHtmls.length).toBe(1);
+        });
+
+        it('resolves the FIRST matching instance for duplicate reference values', () => {
+            // Two instances share reference="50". Document order must win (first match),
+            // matching the former getElementsByAttribute(...)[0] behavior.
+            const legacyXml = `<?xml version="1.0" encoding="utf-8"?>
+<instance class="exe.engine.package.Package" reference="1">
+  <dictionary>
+    <string role="key" value="_title"/>
+    <unicode value="Project"/>
+    <string role="key" value="_root"/>
+    <instance class="exe.engine.node.Node" reference="2">
+      <dictionary>
+        <string role="key" value="_title"/>
+        <unicode value="Root"/>
+        <string role="key" value="parent"/>
+        <none/>
+        <string role="key" value="idevices"/>
+        <list>
+          <instance class="exe.engine.freetextidevice.FreeTextIdevice" reference="50">
+            <dictionary>
+              <string role="key" value="fields"/>
+              <list>
+                <instance class="exe.engine.field.TextAreaField" reference="60">
+                  <dictionary>
+                    <string role="key" value="content_w_resourcePaths"/>
+                    <unicode value="&lt;p&gt;FIRST instance&lt;/p&gt;"/>
+                  </dictionary>
+                </instance>
+              </list>
+            </dictionary>
+          </instance>
+          <instance class="exe.engine.freetextidevice.FreeTextIdevice" reference="50">
+            <dictionary>
+              <string role="key" value="fields"/>
+              <list>
+                <instance class="exe.engine.field.TextAreaField" reference="61">
+                  <dictionary>
+                    <string role="key" value="content_w_resourcePaths"/>
+                    <unicode value="&lt;p&gt;SECOND instance&lt;/p&gt;"/>
+                  </dictionary>
+                </instance>
+              </list>
+            </dictionary>
+          </instance>
+          <reference key="50"/>
+        </list>
+      </dictionary>
+    </instance>
+  </dictionary>
+</instance>`;
+
+            const result = parser.parse(legacyXml);
+            const page = result.pages.find(p => p.title === 'Root');
+            expect(page).toBeDefined();
+
+            const ideviceHtmls = page!.blocks.flatMap(b => b.idevices.map(d => d.htmlView));
+            // The <reference key="50"/> must resolve to the FIRST instance's content.
+            const resolvedFromReference = ideviceHtmls.filter(html => html.includes('FIRST instance'));
+            expect(resolvedFromReference.length).toBe(2); // inline first + referenced (same first instance)
+            expect(ideviceHtmls.some(html => html.includes('SECOND instance'))).toBe(true);
+        });
+
+        it('scales to many cross-referencing instances without per-reference full scans', () => {
+            // Build a document with one inline iDevice per page plus one back-reference per
+            // page. With the previous O(N^2) full-document scan this pinned the event loop
+            // for tens of seconds; the precomputed map makes it complete near-instantly.
+            const pageCount = 4000;
+            const pieces: string[] = [];
+            pieces.push('<?xml version="1.0" encoding="utf-8"?>');
+            pieces.push('<instance class="exe.engine.package.Package" reference="1">');
+            pieces.push('  <dictionary>');
+            pieces.push('    <string role="key" value="_title"/>');
+            pieces.push('    <unicode value="Big Project"/>');
+            pieces.push('    <string role="key" value="_root"/>');
+            pieces.push('    <instance class="exe.engine.node.Node" reference="2">');
+            pieces.push('      <dictionary>');
+            pieces.push('        <string role="key" value="_title"/>');
+            pieces.push('        <unicode value="Root"/>');
+            pieces.push('        <string role="key" value="parent"/>');
+            pieces.push('        <none/>');
+            pieces.push('        <string role="key" value="children"/>');
+            pieces.push('        <list>');
+
+            for (let i = 0; i < pageCount; i++) {
+                const nodeRef = 1000 + i * 3;
+                const ideviceRef = nodeRef + 1;
+                const fieldRef = nodeRef + 2;
+                pieces.push(`          <instance class="exe.engine.node.Node" reference="${nodeRef}">`);
+                pieces.push('            <dictionary>');
+                pieces.push('              <string role="key" value="_title"/>');
+                pieces.push(`              <unicode value="Page ${i}"/>`);
+                pieces.push('              <string role="key" value="parent"/>');
+                pieces.push('              <reference key="2"/>');
+                pieces.push('              <string role="key" value="idevices"/>');
+                pieces.push('              <list>');
+                // Inline iDevice declared on the first page that owns this reference.
+                pieces.push(
+                    `                <instance class="exe.engine.freetextidevice.FreeTextIdevice" reference="${ideviceRef}">`,
+                );
+                pieces.push('                  <dictionary>');
+                pieces.push('                    <string role="key" value="fields"/>');
+                pieces.push('                    <list>');
+                pieces.push(
+                    `                      <instance class="exe.engine.field.TextAreaField" reference="${fieldRef}">`,
+                );
+                pieces.push('                        <dictionary>');
+                pieces.push('                          <string role="key" value="content_w_resourcePaths"/>');
+                pieces.push(`                          <unicode value="&lt;p&gt;Content ${i}&lt;/p&gt;"/>`);
+                pieces.push('                        </dictionary>');
+                pieces.push('                      </instance>');
+                pieces.push('                    </list>');
+                pieces.push('                  </dictionary>');
+                pieces.push('                </instance>');
+                // Back-reference to the iDevice declared on the very first generated page,
+                // forcing a reference resolution on every page.
+                pieces.push('                <reference key="1001"/>');
+                pieces.push('              </list>');
+                pieces.push('              <string role="key" value="children"/>');
+                pieces.push('              <list/>');
+                pieces.push('            </dictionary>');
+                pieces.push('          </instance>');
+            }
+
+            pieces.push('        </list>');
+            pieces.push('        <string role="key" value="idevices"/>');
+            pieces.push('        <list/>');
+            pieces.push('      </dictionary>');
+            pieces.push('    </instance>');
+            pieces.push('  </dictionary>');
+            pieces.push('</instance>');
+
+            const legacyXml = pieces.join('\n');
+
+            const start = Date.now();
+            const result = parser.parse(legacyXml);
+            const elapsed = Date.now() - start;
+
+            // Correctness: every page resolves, and the back-reference resolves to the
+            // first iDevice's content ("Content 0") on every page.
+            expect(result.pages.length).toBeGreaterThanOrEqual(pageCount);
+            const allHtml = result.pages.flatMap(p => p.blocks.flatMap(b => b.idevices.map(d => d.htmlView)));
+            expect(allHtml.filter(html => html.includes('Content 0')).length).toBeGreaterThanOrEqual(pageCount);
+
+            // Generous time bound. The previous full-scan implementation took ~21.8s for
+            // ~10k lookups on a 1.2MB document; with the O(1) map this stays well under 8s.
+            expect(elapsed).toBeLessThan(8000);
+        });
+    });
 });

--- a/src/shared/import/LegacyXmlParser.ts
+++ b/src/shared/import/LegacyXmlParser.ts
@@ -108,6 +108,12 @@ export class LegacyXmlParser {
     private xmlContent: string = '';
     private xmlDoc: Document | null = null;
     private parentRefMap: Map<string, string | null> = new Map();
+    /**
+     * Maps an `instance` element's `reference` attribute value to the element itself.
+     * Built once per parsed document to avoid O(N²) full-document scans when resolving
+     * `<reference key="..."/>` lookups (see {@link getInstanceByReference}).
+     */
+    private instanceByReferenceMap: Map<string, Element> = new Map();
     private projectLanguage: string = '';
     private logger: Logger;
 
@@ -416,6 +422,9 @@ export class LegacyXmlParser {
         // Build parent reference map
         this.buildParentReferenceMap();
 
+        // Build instance-by-reference map once (avoids O(N²) per-reference document scans)
+        this.buildInstanceReferenceMap();
+
         // Find all Node instances (pages)
         const nodes = this.findAllNodes();
         this.logger.log(`[LegacyXmlParser] Found ${nodes.length} legacy nodes`);
@@ -461,6 +470,53 @@ export class LegacyXmlParser {
         }
 
         this.logger.log(`[LegacyXmlParser] Built parent map with ${this.parentRefMap.size} entries`);
+    }
+
+    /**
+     * Build a `reference` -> `instance` element map once for the current document.
+     *
+     * Legacy XML uses `<reference key="N"/>` placeholders that point back to the first
+     * `<instance reference="N">` declared in document order. Previously each placeholder
+     * was resolved with a full-document `getElementsByTagName('instance')` scan, which is
+     * O(N²) across the whole document and could pin the event loop for tens of seconds on
+     * large legacy ELP files with thousands of cross-referencing instances.
+     *
+     * This precomputes the lookup in a single O(N) pass. To preserve the previous
+     * first-match semantics (`getElementsByAttribute(...)[0]`), only the first `instance`
+     * encountered for a given `reference` value is stored.
+     */
+    private buildInstanceReferenceMap(): void {
+        // Rebuild from scratch so the map always reflects the current document, even if
+        // the same parser instance is reused across multiple parse() calls.
+        this.instanceByReferenceMap.clear();
+        if (!this.xmlDoc) return;
+
+        // getElementsByTagName returns elements in document order, matching the order the
+        // previous filter-based lookup relied on for first-match resolution.
+        const instances = this.getElementsByTagName(this.xmlDoc, 'instance');
+        for (const inst of instances) {
+            const ref = inst.getAttribute('reference');
+            if (!ref) continue;
+            if (!this.instanceByReferenceMap.has(ref)) {
+                this.instanceByReferenceMap.set(ref, inst);
+            }
+        }
+
+        this.logger.log(
+            `[LegacyXmlParser] Built instance reference map with ${this.instanceByReferenceMap.size} entries`,
+        );
+    }
+
+    /**
+     * Resolve a `<reference key="..."/>` placeholder to its target `instance` element.
+     *
+     * O(1) replacement for the former
+     * `getElementsByAttribute(this.xmlDoc, 'instance', 'reference', refKey)[0]` scans.
+     * Returns `undefined` when no matching instance exists, mirroring the previous
+     * `[0]`-on-empty-array behavior so callers' missing-reference handling is unchanged.
+     */
+    private getInstanceByReference(refKey: string): Element | undefined {
+        return this.instanceByReferenceMap.get(refKey);
     }
 
     /**
@@ -1211,12 +1267,7 @@ export class LegacyXmlParser {
             } else if (child.tagName === 'reference') {
                 const refKey = child.getAttribute('key');
                 if (refKey && this.xmlDoc) {
-                    const referencedInstance = this.getElementsByAttribute(
-                        this.xmlDoc,
-                        'instance',
-                        'reference',
-                        refKey,
-                    )[0];
+                    const referencedInstance = this.getInstanceByReference(refKey);
                     if (referencedInstance) {
                         this.logger.log(`[LegacyXmlParser] Resolved reference key=${refKey} to instance`);
                         instancesToProcess.push(referencedInstance);
@@ -2044,12 +2095,7 @@ export class LegacyXmlParser {
                         } else if (fieldChild.tagName === 'reference') {
                             const refKey = fieldChild.getAttribute('key');
                             if (refKey && this.xmlDoc) {
-                                const referencedInstance = this.getElementsByAttribute(
-                                    this.xmlDoc,
-                                    'instance',
-                                    'reference',
-                                    refKey,
-                                )[0];
+                                const referencedInstance = this.getInstanceByReference(refKey);
                                 if (referencedInstance) {
                                     this.logger.log(`[LegacyXmlParser] Resolved field reference key=${refKey}`);
                                     fieldInstances.push(referencedInstance);
@@ -2200,12 +2246,7 @@ export class LegacyXmlParser {
                 if (valueEl.tagName === 'reference') {
                     const refKey = valueEl.getAttribute('key');
                     if (refKey && this.xmlDoc) {
-                        const referencedInstance = this.getElementsByAttribute(
-                            this.xmlDoc,
-                            'instance',
-                            'reference',
-                            refKey,
-                        )[0];
+                        const referencedInstance = this.getInstanceByReference(refKey);
                         if (referencedInstance) {
                             const refClass = referencedInstance.getAttribute('class') || '';
                             if (refClass.includes('TextAreaField') || refClass.includes('TextField')) {

--- a/src/utils/admin-route-helpers.spec.ts
+++ b/src/utils/admin-route-helpers.spec.ts
@@ -233,25 +233,41 @@ describe('Admin Route Helpers', () => {
             process.env = { ...originalEnv };
         });
 
-        test('should return JWT_SECRET if set', () => {
+        // getJwtSecret now delegates to the single canonical resolver in
+        // routes/auth (API_JWT_SECRET || JWT_SECRET || 'dev_secret_change_me'),
+        // so the verify secret always matches the sign secret. APP_SECRET is no
+        // longer used for internal-auth verification (it is only for platform
+        // JWTs) — see H3.
+        test('should prefer API_JWT_SECRET when set', () => {
+            process.env.API_JWT_SECRET = 'api-secret';
+            process.env.JWT_SECRET = 'my-jwt-secret';
+
+            expect(getJwtSecret()).toBe('api-secret');
+        });
+
+        test('should return JWT_SECRET when API_JWT_SECRET is not set', () => {
+            delete process.env.API_JWT_SECRET;
             process.env.JWT_SECRET = 'my-jwt-secret';
             process.env.APP_SECRET = 'my-app-secret';
 
             expect(getJwtSecret()).toBe('my-jwt-secret');
         });
 
-        test('should return APP_SECRET if JWT_SECRET not set', () => {
+        test('should NOT fall back to APP_SECRET for internal auth', () => {
+            delete process.env.API_JWT_SECRET;
             delete process.env.JWT_SECRET;
             process.env.APP_SECRET = 'my-app-secret';
 
-            expect(getJwtSecret()).toBe('my-app-secret');
+            expect(getJwtSecret()).not.toBe('my-app-secret');
+            expect(getJwtSecret()).toBe('dev_secret_change_me');
         });
 
-        test('should return default if no env vars set', () => {
+        test('should return the canonical default if no env vars set', () => {
+            delete process.env.API_JWT_SECRET;
             delete process.env.JWT_SECRET;
             delete process.env.APP_SECRET;
 
-            expect(getJwtSecret()).toBe('elysia-dev-secret-change-me');
+            expect(getJwtSecret()).toBe('dev_secret_change_me');
         });
     });
 });

--- a/src/utils/admin-route-helpers.ts
+++ b/src/utils/admin-route-helpers.ts
@@ -3,6 +3,7 @@
  * Shared utilities for admin CRUD routes
  */
 import * as fs from 'fs-extra';
+import { getJwtSecret as canonicalJwtSecret } from '../routes/auth';
 
 // ============================================================================
 // HTTP STATUS HELPERS
@@ -89,8 +90,15 @@ export function getFilesDir(): string {
 }
 
 /**
- * Get the JWT secret from environment variables
+ * Get the JWT secret from environment variables.
+ *
+ * Delegates to the single canonical resolver in routes/auth so the secret used
+ * to VERIFY admin/theme/template tokens always matches the one used to SIGN
+ * them. Previously this resolved `JWT_SECRET || APP_SECRET || <public default>`,
+ * which diverged from the signing secret (`API_JWT_SECRET || JWT_SECRET || ...`)
+ * and could either lock admins out or — if APP_SECRET was unset — fall back to a
+ * public in-repo constant, enabling token forgery (H3).
  */
 export function getJwtSecret(): string {
-    return process.env.JWT_SECRET || process.env.APP_SECRET || 'elysia-dev-secret-change-me';
+    return canonicalJwtSecret();
 }

--- a/src/utils/platform-jwt.spec.ts
+++ b/src/utils/platform-jwt.spec.ts
@@ -4,6 +4,7 @@ import {
     getProviderSecret,
     isValidProvider,
     isAllowedProviderUrl,
+    isSafeReturnUrl,
     extractProviderId,
     decodePlatformJWT,
     buildIntegrationUrl,
@@ -146,10 +147,14 @@ describe('Platform JWT Utilities', () => {
     });
 
     describe('isAllowedProviderUrl', () => {
-        it('should return true when no providers configured', () => {
+        // SECURITY (bug M3): this is an allow-list and now FAILS CLOSED. Previously
+        // an empty PROVIDER_URLS (the shipped default) returned true for any URL,
+        // which enabled SSRF via the JWT returnurl. With no providers configured
+        // nothing is allowed, so platform integration requires an explicit list.
+        it('should return false when no providers configured (fail closed)', () => {
             delete process.env.PROVIDER_URLS;
 
-            expect(isAllowedProviderUrl('https://any-domain.com/path')).toBe(true);
+            expect(isAllowedProviderUrl('https://any-domain.com/path')).toBe(false);
         });
 
         it('should return true for URL matching a configured provider', () => {
@@ -169,6 +174,41 @@ describe('Platform JWT Utilities', () => {
             process.env.PROVIDER_URLS = 'https://moodle.example.com';
 
             expect(isAllowedProviderUrl('')).toBe(false);
+        });
+    });
+
+    describe('isSafeReturnUrl', () => {
+        it('should allow public http(s) hostnames', () => {
+            expect(isSafeReturnUrl('https://moodle.example.com/mod/exescorm/view.php?id=1')).toBe(true);
+            expect(isSafeReturnUrl('http://moodle.example.com/mod/exeweb/view.php')).toBe(true);
+        });
+
+        it('should allow a public IP literal host', () => {
+            expect(isSafeReturnUrl('https://8.8.8.8/mod/exescorm/view.php')).toBe(true);
+        });
+
+        it('should reject empty and unparseable URLs', () => {
+            expect(isSafeReturnUrl('')).toBe(false);
+            expect(isSafeReturnUrl('not a url')).toBe(false);
+        });
+
+        it('should reject non-http(s) schemes', () => {
+            expect(isSafeReturnUrl('file:///etc/passwd')).toBe(false);
+            expect(isSafeReturnUrl('ftp://moodle.example.com/x')).toBe(false);
+            expect(isSafeReturnUrl('gopher://moodle.example.com/x')).toBe(false);
+        });
+
+        it('should reject internal IPv4 literal hosts (SSRF guard)', () => {
+            expect(isSafeReturnUrl('http://127.0.0.1/mod/exescorm/view.php')).toBe(false);
+            expect(isSafeReturnUrl('http://10.0.0.5/mod/exescorm/view.php')).toBe(false);
+            expect(isSafeReturnUrl('http://192.168.1.10/mod/exescorm/view.php')).toBe(false);
+            // Cloud metadata endpoint (link-local).
+            expect(isSafeReturnUrl('http://169.254.169.254/latest/meta-data/')).toBe(false);
+        });
+
+        it('should reject internal IPv6 literal hosts (SSRF guard)', () => {
+            expect(isSafeReturnUrl('http://[::1]/mod/exescorm/view.php')).toBe(false);
+            expect(isSafeReturnUrl('http://[fe80::1]/mod/exescorm/view.php')).toBe(false);
         });
     });
 
@@ -416,7 +456,10 @@ describe('Platform JWT Utilities', () => {
         beforeEach(() => {
             process.env.APP_SECRET = 'test-secret';
             delete process.env.PROVIDER_IDS;
-            delete process.env.PROVIDER_URLS;
+            // SECURITY (bug M3): isAllowedProviderUrl now fails closed, so the
+            // legitimate success path requires an explicit allow-list that
+            // matches the token's returnurl host (https://moodle.com).
+            process.env.PROVIDER_URLS = 'https://moodle.com';
         });
 
         it('should return params with platformIntegrationUrl for set operation', async () => {
@@ -460,6 +503,44 @@ describe('Platform JWT Utilities', () => {
 
             const token = await createValidToken({
                 returnurl: 'https://other-moodle.com/mod/exescorm/view.php',
+            });
+
+            const params = await getPlatformIntegrationParams(token, 'set');
+            expect(params).toBeNull();
+        });
+
+        // SECURITY (bug M3): with no PROVIDER_URLS configured the allow-list is
+        // empty and must deny — previously this returned params for any URL.
+        it('should return null when PROVIDER_URLS is empty (fail closed)', async () => {
+            delete process.env.PROVIDER_URLS;
+
+            const token = await createValidToken({
+                returnurl: 'https://moodle.com/mod/exescorm/view.php?id=1',
+            });
+
+            const params = await getPlatformIntegrationParams(token, 'set');
+            expect(params).toBeNull();
+        });
+
+        // SECURITY (bug M3): an internal IP-literal returnurl must be rejected as
+        // a request target even if an allow-list prefix would otherwise match.
+        it('should return null for a returnurl pointing at an internal IP', async () => {
+            process.env.PROVIDER_URLS = 'http://169.254.169.254';
+
+            const token = await createValidToken({
+                returnurl: 'http://169.254.169.254/mod/exescorm/view.php',
+            });
+
+            const params = await getPlatformIntegrationParams(token, 'set');
+            expect(params).toBeNull();
+        });
+
+        // SECURITY (bug M3): a non-http(s) scheme returnurl must be rejected.
+        it('should return null for a returnurl with a non-http(s) scheme', async () => {
+            process.env.PROVIDER_URLS = 'file://';
+
+            const token = await createValidToken({
+                returnurl: 'file:///mod/exescorm/etc/passwd',
             });
 
             const params = await getPlatformIntegrationParams(token, 'set');

--- a/src/utils/platform-jwt.ts
+++ b/src/utils/platform-jwt.ts
@@ -8,6 +8,8 @@
  * - Platform JWT: signed with APP_SECRET or PROVIDER_TOKENS[i], payload {userid, cmid, returnurl, pkgtype}
  */
 import { jwtVerify } from 'jose';
+import { isIP } from 'node:net';
+import { isBlockedAddress } from './ssrf-guard';
 
 /**
  * Payload structure for platform JWT tokens
@@ -107,16 +109,25 @@ export function isValidProvider(providerId: string): boolean {
 }
 
 /**
- * Check if a URL belongs to a configured provider
+ * Check if a URL belongs to a configured provider.
+ *
+ * This is an allow-list, so it FAILS CLOSED: when no providers are configured
+ * (the shipped default), nothing is allowed. The previous behavior returned
+ * `true` for any URL when PROVIDER_URLS was empty, which — combined with the
+ * server deriving its callback target from the attacker-controlled JWT
+ * `returnurl` — let a holder of a valid platform JWT drive the server to fetch
+ * arbitrary internal hosts (SSRF). Deploying platform integration now requires
+ * an explicit PROVIDER_URLS allow-list.
+ *
  * @param url - The URL to validate
  * @returns true if URL is from an allowed provider, false otherwise
  */
 export function isAllowedProviderUrl(url: string): boolean {
     const config = getProviderConfig();
 
-    // If no providers configured, allow all
+    // No providers configured => empty allow-list => nothing is allowed.
     if (config.urls.length === 0) {
-        return true;
+        return false;
     }
 
     if (!url) {
@@ -124,6 +135,58 @@ export function isAllowedProviderUrl(url: string): boolean {
     }
 
     return config.urls.some(allowedUrl => url.startsWith(allowedUrl));
+}
+
+/**
+ * Synchronous guard for a platform return URL used to derive a server-side
+ * request target (see {@link buildIntegrationUrl} and platform callbacks).
+ *
+ * Rejects:
+ *   - URLs that do not parse,
+ *   - schemes other than http(s) (e.g. file:, gopher:, ftp:),
+ *   - hosts that are IP literals flagged by {@link isBlockedAddress}
+ *     (loopback / private / link-local — including cloud metadata
+ *     169.254.169.254 — CGNAT, multicast, reserved, unspecified).
+ *
+ * This is intentionally synchronous and does NOT perform DNS resolution, so it
+ * can run inside the synchronous URL-building path. The allow-list check in
+ * {@link isAllowedProviderUrl} is the primary control; this is defense in depth
+ * against an attacker-supplied IP-literal returnurl. For full DNS-aware egress
+ * filtering (including DNS rebinding), the outbound request should additionally
+ * go through `assertUrlAllowed` / `safeFetch` from `./ssrf-guard`.
+ *
+ * @param url - The return URL from the JWT payload
+ * @returns true if the URL is safe to use as a request target, false otherwise
+ */
+export function isSafeReturnUrl(url: string): boolean {
+    if (!url) {
+        return false;
+    }
+
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return false;
+    }
+
+    // url.hostname keeps brackets for IPv6 literals; strip them for the IP check.
+    const host = parsed.hostname.replace(/^\[/, '').replace(/\]$/, '');
+    if (!host) {
+        return false;
+    }
+
+    // If the host is an IP literal, reject blocked ranges synchronously.
+    // Hostnames are left to the allow-list (and DNS-aware guard at fetch time).
+    if (isIP(host) !== 0 && isBlockedAddress(host)) {
+        return false;
+    }
+
+    return true;
 }
 
 /**
@@ -232,6 +295,13 @@ export async function getPlatformIntegrationParams(
     const providerId = extractProviderId(payload);
     if (providerId && !isValidProvider(providerId)) {
         console.warn(`[PlatformJWT] Invalid provider ID in JWT: ${providerId}`);
+        return null;
+    }
+
+    // Reject obviously-unsafe return URLs (non-http(s) scheme, internal IP
+    // literal) before they can become a server-side request target (SSRF).
+    if (!isSafeReturnUrl(payload.returnurl)) {
+        console.warn(`[PlatformJWT] Unsafe return URL rejected: ${payload.returnurl}`);
         return null;
     }
 

--- a/src/utils/safe-path.spec.ts
+++ b/src/utils/safe-path.spec.ts
@@ -1,0 +1,140 @@
+import * as nodePath from 'path';
+import {
+    assertSafePathSegment,
+    isSafePathSegment,
+    isWithinBase,
+    safeJoin,
+    sanitizeFileExtension,
+    UnsafePathError,
+} from './safe-path';
+
+describe('safe-path', () => {
+    describe('isSafePathSegment', () => {
+        it('accepts plain identifiers (UUIDs, slugs, timestamps)', () => {
+            expect(isSafePathSegment('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+            expect(isSafePathSegment('my_theme-01')).toBe(true);
+            expect(isSafePathSegment('20240131120000abcDEF')).toBe(true);
+        });
+
+        it('rejects non-string input', () => {
+            expect(isSafePathSegment(undefined)).toBe(false);
+            expect(isSafePathSegment(null)).toBe(false);
+            expect(isSafePathSegment(123 as unknown)).toBe(false);
+        });
+
+        it('rejects empty and over-long segments', () => {
+            expect(isSafePathSegment('')).toBe(false);
+            expect(isSafePathSegment('a'.repeat(256))).toBe(false);
+            expect(isSafePathSegment('a'.repeat(255))).toBe(true);
+            expect(isSafePathSegment('abc', { maxLength: 2 })).toBe(false);
+        });
+
+        it('rejects traversal tokens', () => {
+            expect(isSafePathSegment('.')).toBe(false);
+            expect(isSafePathSegment('..')).toBe(false);
+        });
+
+        it('rejects path separators (forward and back slash)', () => {
+            expect(isSafePathSegment('../etc')).toBe(false);
+            expect(isSafePathSegment('a/b')).toBe(false);
+            expect(isSafePathSegment('a\\b')).toBe(false);
+            expect(isSafePathSegment('..\\..\\windows')).toBe(false);
+        });
+
+        it('rejects NUL and control characters', () => {
+            const nul = String.fromCharCode(0);
+            const unit = String.fromCharCode(31);
+            const del = String.fromCharCode(127);
+            expect(isSafePathSegment(`file${nul}.png`)).toBe(false);
+            expect(isSafePathSegment('a\tb')).toBe(false);
+            expect(isSafePathSegment(`a${unit}b`)).toBe(false);
+            expect(isSafePathSegment(`a${del}b`)).toBe(false);
+        });
+
+        it('rejects dots unless allowDots is set', () => {
+            expect(isSafePathSegment('name.ext')).toBe(false);
+            expect(isSafePathSegment('name.ext', { allowDots: true })).toBe(true);
+        });
+
+        it('still rejects "." and ".." even with allowDots', () => {
+            expect(isSafePathSegment('..', { allowDots: true })).toBe(false);
+            expect(isSafePathSegment('.', { allowDots: true })).toBe(false);
+        });
+    });
+
+    describe('assertSafePathSegment', () => {
+        it('returns the segment when valid', () => {
+            expect(assertSafePathSegment('valid-id')).toBe('valid-id');
+        });
+
+        it('throws UnsafePathError with the provided label', () => {
+            expect(() => assertSafePathSegment('../x', { label: 'clientId' })).toThrow(UnsafePathError);
+            try {
+                assertSafePathSegment('../x', { label: 'clientId' });
+            } catch (e) {
+                expect((e as Error).message).toBe('Invalid clientId');
+            }
+        });
+    });
+
+    describe('isWithinBase', () => {
+        it('accepts paths inside the base', () => {
+            expect(isWithinBase('/data/assets', 'uuid.png')).toBe(true);
+            expect(isWithinBase('/data/assets', 'sub/uuid.png')).toBe(true);
+        });
+
+        it('accepts the base itself', () => {
+            expect(isWithinBase('/data/assets', '.')).toBe(true);
+        });
+
+        it('rejects traversal escaping the base', () => {
+            expect(isWithinBase('/data/assets', '../../etc/passwd')).toBe(false);
+            expect(isWithinBase('/data/assets', '../secret')).toBe(false);
+        });
+
+        it('rejects sibling directories that share a name prefix (no naive startsWith bypass)', () => {
+            // The classic bug: /data/assets-evil should NOT count as inside /data/assets
+            expect(isWithinBase('/data/assets', '../assets-evil/x')).toBe(false);
+        });
+    });
+
+    describe('safeJoin', () => {
+        const base = nodePath.join(nodePath.sep, 'data', 'assets');
+
+        it('joins valid segments inside the base', () => {
+            const result = safeJoin(base, 'project-uuid', 'asset-id.png');
+            expect(result).toBe(nodePath.join(base, 'project-uuid', 'asset-id.png'));
+        });
+
+        it('throws on a traversal segment instead of escaping the base', () => {
+            expect(() => safeJoin(base, '..', '..', 'tmp', 'pwned')).toThrow(UnsafePathError);
+            expect(() => safeJoin(base, '../../../../tmp/pwned')).toThrow(UnsafePathError);
+        });
+
+        it('throws on separators embedded in a segment', () => {
+            expect(() => safeJoin(base, 'a/b')).toThrow(UnsafePathError);
+        });
+    });
+
+    describe('sanitizeFileExtension', () => {
+        it('returns a safe lowercased extension', () => {
+            expect(sanitizeFileExtension('image.PNG')).toBe('.png');
+            expect(sanitizeFileExtension('archive.tar')).toBe('.tar');
+        });
+
+        it('returns empty string when there is no extension', () => {
+            expect(sanitizeFileExtension('noext')).toBe('');
+            expect(sanitizeFileExtension('')).toBe('');
+        });
+
+        it('rejects extensions with unsafe characters or excessive length', () => {
+            expect(sanitizeFileExtension('evil.php/../x')).toBe('');
+            expect(sanitizeFileExtension(`x.${'a'.repeat(20)}`)).toBe('');
+        });
+
+        it('returns empty string for non-string input', () => {
+            expect(sanitizeFileExtension(undefined)).toBe('');
+            expect(sanitizeFileExtension(null)).toBe('');
+        });
+    });
+});

--- a/src/utils/safe-path.ts
+++ b/src/utils/safe-path.ts
@@ -1,0 +1,124 @@
+/**
+ * Safe path utilities — single source of truth for validating user-supplied
+ * path segments and identifiers before they are used to build on-disk paths.
+ *
+ * Background: several upload/export/theme endpoints concatenated attacker
+ * controlled identifiers (clientId, resumableIdentifier, odeSessionId,
+ * themeName, ideviceId) directly into `path.join(...)`. Because `path.join`
+ * collapses `..` segments, this allowed arbitrary file read/write outside the
+ * intended base directory. These helpers reject unsafe segments up front and
+ * assert containment after the join, so every filesystem sink shares the same
+ * hardened guard instead of re-implementing (and forgetting) it.
+ */
+import * as nodePath from 'path';
+
+/**
+ * Thrown when a path segment is rejected or a resolved path escapes its base.
+ */
+export class UnsafePathError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'UnsafePathError';
+    }
+}
+
+export interface SafeSegmentOptions {
+    /** Allow `.` characters inside the segment (still rejects `.` and `..`). */
+    allowDots?: boolean;
+    /** Maximum allowed length. Defaults to 255. */
+    maxLength?: number;
+}
+
+const DEFAULT_MAX_SEGMENT_LENGTH = 255;
+
+const SEGMENT_CHARS = /^[A-Za-z0-9_-]+$/;
+const SEGMENT_CHARS_WITH_DOTS = /^[A-Za-z0-9._-]+$/;
+
+/** Returns true if the string contains any ASCII control character (incl. NUL/DEL). */
+function hasControlChars(value: string): boolean {
+    for (let i = 0; i < value.length; i++) {
+        const code = value.charCodeAt(i);
+        if (code <= 0x1f || code === 0x7f) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Returns true if `segment` is a single, safe path component: a non-empty,
+ * bounded string with no path separators, no NUL/control characters and which
+ * is not a traversal token (`.` / `..`). By default only `[A-Za-z0-9_-]` is
+ * permitted; pass `allowDots` to also permit `.` (e.g. `name.ext`).
+ */
+export function isSafePathSegment(segment: unknown, opts: SafeSegmentOptions = {}): segment is string {
+    if (typeof segment !== 'string') {
+        return false;
+    }
+    const maxLength = opts.maxLength ?? DEFAULT_MAX_SEGMENT_LENGTH;
+    if (segment.length === 0 || segment.length > maxLength) {
+        return false;
+    }
+    if (segment === '.' || segment === '..') {
+        return false;
+    }
+    if (segment.includes('/') || segment.includes('\\')) {
+        return false;
+    }
+    if (hasControlChars(segment)) {
+        return false;
+    }
+    return (opts.allowDots ? SEGMENT_CHARS_WITH_DOTS : SEGMENT_CHARS).test(segment);
+}
+
+/**
+ * Validates `segment` and returns it unchanged, or throws {@link UnsafePathError}.
+ */
+export function assertSafePathSegment(segment: unknown, opts: SafeSegmentOptions & { label?: string } = {}): string {
+    if (!isSafePathSegment(segment, opts)) {
+        throw new UnsafePathError(`Invalid ${opts.label ?? 'path segment'}`);
+    }
+    return segment;
+}
+
+/**
+ * Returns true if `targetPath`, resolved relative to `baseDir`, stays inside
+ * `baseDir`. Uses a separator-aware prefix check so that `/data/assets-evil`
+ * is NOT considered inside `/data/assets` (a bug in a naive `startsWith`).
+ */
+export function isWithinBase(baseDir: string, targetPath: string): boolean {
+    const resolvedBase = nodePath.resolve(baseDir);
+    const resolvedTarget = nodePath.resolve(baseDir, targetPath);
+    return resolvedTarget === resolvedBase || resolvedTarget.startsWith(resolvedBase + nodePath.sep);
+}
+
+/**
+ * Joins one or more user-supplied segments onto `baseDir`, validating each
+ * segment and asserting the final path stays within `baseDir`. Throws
+ * {@link UnsafePathError} on any violation. This is the preferred way to build
+ * an on-disk path from untrusted input.
+ */
+export function safeJoin(baseDir: string, ...segments: string[]): string {
+    for (const segment of segments) {
+        assertSafePathSegment(segment, { allowDots: true, label: 'path segment' });
+    }
+    const joined = nodePath.join(baseDir, ...segments);
+    if (!isWithinBase(baseDir, joined)) {
+        throw new UnsafePathError('Resolved path escapes base directory');
+    }
+    return joined;
+}
+
+/**
+ * Extracts a safe, lowercased file extension (including the leading dot) from a
+ * filename, or returns '' when there is no acceptable extension. Only short
+ * alphanumeric extensions are accepted, so a crafted filename cannot smuggle
+ * separators or traversal tokens through the extension.
+ */
+export function sanitizeFileExtension(filename: unknown): string {
+    if (typeof filename !== 'string') {
+        return '';
+    }
+    const ext = nodePath.extname(filename).toLowerCase();
+    return /^\.[a-z0-9]{1,12}$/.test(ext) ? ext : '';
+}

--- a/src/utils/ssrf-guard.spec.ts
+++ b/src/utils/ssrf-guard.spec.ts
@@ -1,0 +1,134 @@
+import { assertUrlAllowed, isBlockedAddress, safeFetch, SsrfBlockedError, type LookupFn } from './ssrf-guard';
+
+/** Lookup that always resolves to a given address (hermetic — no real DNS). */
+function lookupTo(address: string): LookupFn {
+    return async () => [{ address }];
+}
+
+function res(status: number, location?: string): Response {
+    const headers = new Headers();
+    if (location) {
+        headers.set('location', location);
+    }
+    return new Response(null, { status, headers });
+}
+
+describe('ssrf-guard', () => {
+    describe('isBlockedAddress', () => {
+        it('blocks loopback, private, link-local and unspecified addresses', () => {
+            expect(isBlockedAddress('127.0.0.1')).toBe(true);
+            expect(isBlockedAddress('10.1.2.3')).toBe(true);
+            expect(isBlockedAddress('172.16.5.4')).toBe(true);
+            expect(isBlockedAddress('192.168.0.1')).toBe(true);
+            expect(isBlockedAddress('169.254.169.254')).toBe(true); // cloud metadata
+            expect(isBlockedAddress('0.0.0.0')).toBe(true);
+            expect(isBlockedAddress('::1')).toBe(true);
+            expect(isBlockedAddress('fe80::1')).toBe(true);
+            expect(isBlockedAddress('fc00::1')).toBe(true);
+        });
+
+        it('blocks CGNAT / reserved / multicast ranges', () => {
+            expect(isBlockedAddress('100.64.1.1')).toBe(true);
+            expect(isBlockedAddress('224.0.0.1')).toBe(true);
+            expect(isBlockedAddress('240.0.0.1')).toBe(true);
+        });
+
+        it('allows public addresses', () => {
+            expect(isBlockedAddress('8.8.8.8')).toBe(false);
+            expect(isBlockedAddress('93.184.216.34')).toBe(false);
+            expect(isBlockedAddress('2606:2800:220:1:248:1893:25c8:1946')).toBe(false);
+        });
+
+        it('treats empty input as blocked', () => {
+            expect(isBlockedAddress('')).toBe(true);
+        });
+    });
+
+    describe('assertUrlAllowed', () => {
+        it('rejects non-http(s) schemes', async () => {
+            await expect(assertUrlAllowed('file:///etc/passwd')).rejects.toBeInstanceOf(SsrfBlockedError);
+            await expect(assertUrlAllowed('ftp://example.com/x')).rejects.toBeInstanceOf(SsrfBlockedError);
+            await expect(assertUrlAllowed('gopher://example.com')).rejects.toBeInstanceOf(SsrfBlockedError);
+        });
+
+        it('rejects an IP literal that is loopback/private without DNS', async () => {
+            await expect(assertUrlAllowed('http://127.0.0.1/')).rejects.toBeInstanceOf(SsrfBlockedError);
+            await expect(assertUrlAllowed('http://169.254.169.254/latest/meta-data/')).rejects.toBeInstanceOf(
+                SsrfBlockedError,
+            );
+            await expect(assertUrlAllowed('http://[::1]/')).rejects.toBeInstanceOf(SsrfBlockedError);
+        });
+
+        it('rejects a public host that resolves to a private address', async () => {
+            await expect(
+                assertUrlAllowed('https://rebind.evil.example/', { lookupFn: lookupTo('10.0.0.5') }),
+            ).rejects.toBeInstanceOf(SsrfBlockedError);
+        });
+
+        it('allows a public host that resolves to a public address', async () => {
+            const url = await assertUrlAllowed('https://example.com/page', { lookupFn: lookupTo('93.184.216.34') });
+            expect(url.hostname).toBe('example.com');
+        });
+
+        it('rejects a host that does not resolve', async () => {
+            const failing: LookupFn = async () => {
+                throw new Error('ENOTFOUND');
+            };
+            await expect(assertUrlAllowed('https://nope.invalid/', { lookupFn: failing })).rejects.toBeInstanceOf(
+                SsrfBlockedError,
+            );
+        });
+    });
+
+    describe('safeFetch', () => {
+        it('fetches a safe URL', async () => {
+            let called = '';
+            const fetchImpl = (async (url: string) => {
+                called = String(url);
+                return res(200);
+            }) as unknown as typeof fetch;
+            const response = await safeFetch('https://example.com/ok', {
+                lookupFn: lookupTo('93.184.216.34'),
+                fetchImpl,
+            });
+            expect(response.status).toBe(200);
+            expect(called).toBe('https://example.com/ok');
+        });
+
+        it('follows a redirect to another public host', async () => {
+            const fetchImpl = (async (url: string) => {
+                if (String(url) === 'https://a.example/') {
+                    return res(302, 'https://b.example/landing');
+                }
+                return res(200);
+            }) as unknown as typeof fetch;
+            const response = await safeFetch('https://a.example/', {
+                lookupFn: lookupTo('93.184.216.34'),
+                fetchImpl,
+            });
+            expect(response.status).toBe(200);
+        });
+
+        it('blocks a redirect that points at an internal address', async () => {
+            // First hop resolves public, then redirects to a host resolving to loopback.
+            const lookupFn: LookupFn = async hostname =>
+                hostname === 'public.example' ? [{ address: '93.184.216.34' }] : [{ address: '127.0.0.1' }];
+            const fetchImpl = (async (url: string) => {
+                if (String(url) === 'https://public.example/') {
+                    return res(302, 'http://internal.example/admin');
+                }
+                return res(200);
+            }) as unknown as typeof fetch;
+            await expect(safeFetch('https://public.example/', { lookupFn, fetchImpl })).rejects.toBeInstanceOf(
+                SsrfBlockedError,
+            );
+        });
+
+        it('stops after too many redirects', async () => {
+            const fetchImpl = (async () => res(302, 'https://loop.example/next')) as unknown as typeof fetch;
+            await expect(
+                safeFetch('https://loop.example/', { lookupFn: lookupTo('93.184.216.34'), fetchImpl, maxRedirects: 2 }),
+            ).rejects.toBeInstanceOf(SsrfBlockedError);
+        });
+    });
+});

--- a/src/utils/ssrf-guard.ts
+++ b/src/utils/ssrf-guard.ts
@@ -1,0 +1,151 @@
+/**
+ * SSRF guard — a safe wrapper around fetch for server-side requests to
+ * user-influenced URLs.
+ *
+ * Background: server-side link validation and platform callbacks fetched
+ * arbitrary attacker-supplied URLs with `redirect: 'follow'` and no egress
+ * filtering, allowing SSRF to loopback / RFC1918 / link-local (cloud metadata
+ * 169.254.169.254) and an internal-port oracle. This guard:
+ *   - allows only http(s) schemes,
+ *   - resolves the host and rejects requests whose resolved address is
+ *     private/loopback/link-local/CGNAT/unspecified,
+ *   - follows redirects MANUALLY, re-validating the host of every hop (so a
+ *     public host cannot redirect to an internal one),
+ *   - is dependency-injectable (DNS lookup + fetch) for hermetic tests.
+ */
+import { isIP } from 'node:net';
+import { lookup } from 'node:dns/promises';
+import { isIpInCidr, isPrivateIp } from './proxy-url.util';
+
+/** Thrown when a URL/host is rejected by the SSRF guard. */
+export class SsrfBlockedError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SsrfBlockedError';
+    }
+}
+
+/** Extra IPv4 ranges that are not "private" per RFC1918 but must not be reachable. */
+const EXTRA_BLOCKED_V4_CIDRS = [
+    '0.0.0.0/8', // "this host"
+    '100.64.0.0/10', // CGNAT
+    '192.0.0.0/24', // IETF protocol assignments
+    '198.18.0.0/15', // benchmarking
+    '224.0.0.0/4', // multicast
+    '240.0.0.0/4', // reserved
+];
+
+export type LookupFn = (hostname: string) => Promise<Array<{ address: string }>>;
+
+const defaultLookup: LookupFn = async hostname => {
+    const result = await lookup(hostname, { all: true });
+    return result.map(r => ({ address: r.address }));
+};
+
+/**
+ * Returns true if the given resolved IP must not be contacted (loopback,
+ * private, link-local, CGNAT, unspecified, multicast, reserved...).
+ */
+export function isBlockedAddress(ip: string): boolean {
+    if (!ip) {
+        return true;
+    }
+    // Strip an IPv6 zone id (e.g. fe80::1%eth0).
+    const addr = ip.split('%')[0].trim();
+    if (addr === '' || addr === '0.0.0.0' || addr === '::' || addr === '0:0:0:0:0:0:0:0') {
+        return true;
+    }
+    if (isPrivateIp(addr)) {
+        return true;
+    }
+    if (isIP(addr) === 4) {
+        for (const cidr of EXTRA_BLOCKED_V4_CIDRS) {
+            if (isIpInCidr(addr, cidr)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+export interface AssertUrlAllowedOptions {
+    lookupFn?: LookupFn;
+}
+
+/**
+ * Validate a single URL: must be http(s) and must not resolve to a blocked
+ * address. Throws {@link SsrfBlockedError} otherwise. Returns the parsed URL.
+ */
+export async function assertUrlAllowed(urlStr: string, opts: AssertUrlAllowedOptions = {}): Promise<URL> {
+    let url: URL;
+    try {
+        url = new URL(urlStr);
+    } catch {
+        throw new SsrfBlockedError('Invalid URL');
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        throw new SsrfBlockedError(`Disallowed scheme: ${url.protocol}`);
+    }
+    // url.hostname keeps brackets for IPv6 literals; strip them for isIP/checks.
+    const host = url.hostname.replace(/^\[/, '').replace(/\]$/, '');
+    if (!host) {
+        throw new SsrfBlockedError('Missing host');
+    }
+
+    let addresses: string[];
+    if (isIP(host) !== 0) {
+        addresses = [host];
+    } else {
+        const lookupFn = opts.lookupFn ?? defaultLookup;
+        let resolved: Array<{ address: string }>;
+        try {
+            resolved = await lookupFn(host);
+        } catch {
+            throw new SsrfBlockedError('Host did not resolve');
+        }
+        addresses = resolved.map(r => r.address);
+        if (addresses.length === 0) {
+            throw new SsrfBlockedError('Host did not resolve');
+        }
+    }
+
+    for (const address of addresses) {
+        if (isBlockedAddress(address)) {
+            throw new SsrfBlockedError(`Blocked address for host ${host}: ${address}`);
+        }
+    }
+    return url;
+}
+
+export interface SafeFetchOptions extends RequestInit {
+    /** Maximum redirect hops to follow (each re-validated). Default 5. */
+    maxRedirects?: number;
+    /** Injectable DNS resolver (for tests). */
+    lookupFn?: LookupFn;
+    /** Injectable fetch implementation (for tests). */
+    fetchImpl?: typeof fetch;
+}
+
+/**
+ * Fetch a URL with SSRF protection. Validates the initial URL and every
+ * redirect hop against {@link isBlockedAddress}; redirects are followed
+ * manually so the host of each hop is checked before the next request.
+ */
+export async function safeFetch(urlStr: string, options: SafeFetchOptions = {}): Promise<Response> {
+    const { maxRedirects = 5, lookupFn, fetchImpl = fetch, ...init } = options;
+    let currentUrl = urlStr;
+
+    for (let hop = 0; hop <= maxRedirects; hop++) {
+        await assertUrlAllowed(currentUrl, { lookupFn });
+        const response = await fetchImpl(currentUrl, { ...init, redirect: 'manual' });
+
+        const location = response.headers.get('location');
+        const isRedirect = response.status >= 300 && response.status < 400 && location;
+        if (!isRedirect) {
+            return response;
+        }
+        // Resolve the next hop relative to the current URL and re-validate.
+        currentUrl = new URL(location, currentUrl).toString();
+    }
+    throw new SsrfBlockedError('Too many redirects');
+}

--- a/src/websocket/asset-coordinator.spec.ts
+++ b/src/websocket/asset-coordinator.spec.ts
@@ -1471,4 +1471,275 @@ describe('Asset Coordinator Service (DI)', () => {
             coordinator.cleanupProject('prune-project');
         });
     });
+
+    // =========================================================================
+    // DoS hardening — bounded pending-request queue (BUG H8)
+    // =========================================================================
+    describe('DoS hardening - pending-request bounds', () => {
+        // Mirror of MAX_PENDING_REQUESTS_PER_PROJECT in asset-coordinator.ts.
+        const MAX_PENDING_REQUESTS_PER_PROJECT = 5000;
+
+        it('should append additional requests for the same missing asset under one key', async () => {
+            const socket1 = createMockSocket();
+            const socket2 = createMockSocket();
+            coordinator.registerClient('test-project', 'client-1', socket1);
+            coordinator.registerClient('test-project', 'client-2', socket2);
+
+            // Two distinct clients request the SAME missing asset. The second
+            // request must append to the existing pending key rather than create
+            // a new one, so the project's distinct pending-key count stays at 1.
+            await coordinator.handleMessage('test-project', 'client-1', {
+                type: 'request-asset',
+                data: { assetId: 'shared-missing', priority: 'low' },
+            });
+            await coordinator.handleMessage('test-project', 'client-2', {
+                type: 'request-asset',
+                data: { assetId: 'shared-missing', priority: 'high' },
+            });
+
+            // Both requesters received an asset-not-found response.
+            expect(socket1.messages.length).toBeGreaterThan(0);
+            expect(socket2.messages.length).toBeGreaterThan(0);
+
+            // getStats reports the number of distinct pending-request keys; the
+            // two requests for the same asset collapse into one key.
+            expect(coordinator.getStats().pendingRequests).toBe(1);
+
+            coordinator.cleanupProject('test-project');
+        });
+
+        it('should drop new pending requests once the per-project cap is reached', async () => {
+            const socket = createMockSocket();
+            // Use the known project (resolves via mock) so requests reach the
+            // pending-queue path: project exists, asset is absent from DB, and no
+            // peer announced it.
+            coordinator.registerClient('test-project', 'client-1', socket);
+
+            // Queue exactly the cap number of distinct missing-asset requests.
+            for (let i = 0; i < MAX_PENDING_REQUESTS_PER_PROJECT; i++) {
+                await coordinator.handleMessage('test-project', 'client-1', {
+                    type: 'request-asset',
+                    data: { assetId: `pending-${i}`, priority: 'low' },
+                });
+            }
+            expect(coordinator.getStats().pendingRequests).toBe(MAX_PENDING_REQUESTS_PER_PROJECT);
+
+            // One more distinct id must be dropped (cap enforced), keeping the
+            // distinct pending-key count pinned at the ceiling.
+            await coordinator.handleMessage('test-project', 'client-1', {
+                type: 'request-asset',
+                data: { assetId: 'one-too-many', priority: 'low' },
+            });
+            expect(coordinator.getStats().pendingRequests).toBe(MAX_PENDING_REQUESTS_PER_PROJECT);
+
+            coordinator.cleanupProject('test-project');
+        });
+    });
+
+    // =========================================================================
+    // Asset-id validation on request-asset (BUG H8)
+    // =========================================================================
+    describe('request-asset id validation', () => {
+        it('should reject a request whose asset id contains traversal/separators', async () => {
+            const socket = createMockSocket();
+            coordinator.registerClient('test-project', 'client-1', socket);
+
+            // An id with a path separator must be rejected before any DB lookup,
+            // pending-queue insert, or peer routing — no response is emitted and
+            // no pending request is tracked.
+            await coordinator.handleMessage('test-project', 'client-1', {
+                type: 'request-asset',
+                data: { assetId: '../escape', priority: 'high' },
+            });
+
+            expect(socket.messages.length).toBe(0);
+            expect(coordinator.getStats().pendingRequests).toBe(0);
+
+            coordinator.cleanupProject('test-project');
+        });
+    });
+
+    // =========================================================================
+    // Upload session — callback wiring and error handling
+    // =========================================================================
+    describe('Upload session — callback wiring and failures', () => {
+        // Builds a coordinator with a fully controllable uploadSessionManager so
+        // we can drive the validateSession-fails path, the progress/batch
+        // callback bodies, and the catch-all error handler deterministically.
+        function buildCoordinator(
+            uploadSessionManager: any,
+            project: any = { id: 7, uuid: 'session-project', user_id: 3 },
+        ): AssetCoordinator {
+            return createAssetCoordinator({
+                ...mockDeps,
+                findProjectByUuid: async (_db: any, uuid: string) => (uuid === 'session-project' ? project : undefined),
+                uploadSessionManager,
+            });
+        }
+
+        const validData = {
+            projectId: 'session-project',
+            totalFiles: 3,
+            totalBytes: 1024,
+            manifest: [],
+        };
+
+        it('should register progress + batch callbacks and forward their events to the client', async () => {
+            let progressCb: ((p: any) => void) | undefined;
+            let batchCb: ((r: any) => void) | undefined;
+
+            const usm = {
+                createSession: async () => ({ sessionToken: 'tok-123', expiresAt: Date.now() + 60_000 }),
+                validateSession: async () => ({ sessionId: 'sess-1', projectId: 'session-project', userId: 3 }),
+                onProgress: (_sessionId: string, cb: (p: any) => void) => {
+                    progressCb = cb;
+                },
+                onBatchComplete: (_sessionId: string, cb: (r: any) => void) => {
+                    batchCb = cb;
+                },
+            };
+
+            const c = buildCoordinator(usm);
+            const socket = createMockSocket();
+            c.registerClient('session-project', 'client-1', socket);
+
+            await c.handleMessage('session-project', 'client-1', {
+                type: 'upload-session-create',
+                data: validData,
+            });
+
+            // Session-ready response must have been sent with the issued token.
+            const decode = (m: any) => JSON.parse(new TextDecoder().decode(m.slice(1)));
+            const ready = socket.messages.map(decode).find((d: any) => d.type === 'upload-session-ready');
+            expect(ready).toBeDefined();
+            expect(ready.data.sessionToken).toBe('tok-123');
+
+            // Both callbacks must have been registered.
+            expect(typeof progressCb).toBe('function');
+            expect(typeof batchCb).toBe('function');
+
+            const before = socket.messages.length;
+
+            // Firing the progress callback must forward an upload-file-progress
+            // message to the originating client.
+            progressCb!({ clientId: 'client-1', bytesWritten: 10, totalBytes: 100, status: 'writing' });
+            const progressMsg = decode(socket.messages[socket.messages.length - 1]);
+            expect(progressMsg.type).toBe('upload-file-progress');
+            expect(progressMsg.data.bytesWritten).toBe(10);
+
+            // Firing the batch-complete callback must forward an
+            // upload-batch-complete message.
+            batchCb!({ uploaded: 3, failed: 0, results: [] });
+            const batchMsg = decode(socket.messages[socket.messages.length - 1]);
+            expect(batchMsg.type).toBe('upload-batch-complete');
+            expect(batchMsg.data.uploaded).toBe(3);
+
+            expect(socket.messages.length).toBe(before + 2);
+
+            c.cleanupProject('session-project');
+        });
+
+        it('should abort silently when the freshly created session token fails validation', async () => {
+            let progressRegistered = false;
+            const usm = {
+                createSession: async () => ({ sessionToken: 'bad-token', expiresAt: Date.now() + 60_000 }),
+                // Simulate a token that cannot be validated.
+                validateSession: async () => null,
+                onProgress: () => {
+                    progressRegistered = true;
+                },
+                onBatchComplete: () => {},
+            };
+
+            const c = buildCoordinator(usm);
+            const socket = createMockSocket();
+            c.registerClient('session-project', 'client-1', socket);
+
+            await c.handleMessage('session-project', 'client-1', {
+                type: 'upload-session-create',
+                data: validData,
+            });
+
+            // No session-ready message and no callback registration: the handler
+            // returns early after logging the validation failure.
+            const hasReady = socket.messages.some(m => {
+                try {
+                    return JSON.parse(new TextDecoder().decode(m.slice(1))).type === 'upload-session-ready';
+                } catch {
+                    return false;
+                }
+            });
+            expect(hasReady).toBe(false);
+            expect(progressRegistered).toBe(false);
+
+            c.cleanupProject('session-project');
+        });
+
+        it('should send an error session-ready response when session creation throws', async () => {
+            const usm = {
+                createSession: async () => {
+                    throw new Error('boom: session storage offline');
+                },
+                validateSession: async () => null,
+                onProgress: () => {},
+                onBatchComplete: () => {},
+            };
+
+            const c = buildCoordinator(usm);
+            const socket = createMockSocket();
+            c.registerClient('session-project', 'client-1', socket);
+
+            await c.handleMessage('session-project', 'client-1', {
+                type: 'upload-session-create',
+                data: validData,
+            });
+
+            // The catch block must send an upload-session-ready carrying the
+            // error message back to the client.
+            const decoded = socket.messages
+                .map(m => {
+                    try {
+                        return JSON.parse(new TextDecoder().decode(m.slice(1)));
+                    } catch {
+                        return null;
+                    }
+                })
+                .find((d: any) => d && d.type === 'upload-session-ready');
+            expect(decoded).toBeDefined();
+            expect(decoded.data.error).toContain('boom');
+            expect(decoded.data.sessionToken).toBe('');
+
+            c.cleanupProject('session-project');
+        });
+
+        it('should not throw when the error-path response also fails to send', async () => {
+            const usm = {
+                createSession: async () => {
+                    throw new Error('primary failure');
+                },
+                validateSession: async () => null,
+                onProgress: () => {},
+                onBatchComplete: () => {},
+            };
+
+            const c = buildCoordinator(usm);
+            const socket = createMockSocket();
+            // The socket throws on send, so even the catch-block's error response
+            // fails; the handler must still not propagate.
+            socket.send = () => {
+                throw new Error('socket dead');
+            };
+            c.registerClient('session-project', 'client-1', socket);
+
+            await c.handleMessage('session-project', 'client-1', {
+                type: 'upload-session-create',
+                data: validData,
+            });
+
+            // Reaching here without throwing is the assertion.
+            expect(true).toBe(true);
+
+            c.cleanupProject('session-project');
+        });
+    });
 });

--- a/src/websocket/asset-coordinator.spec.ts
+++ b/src/websocket/asset-coordinator.spec.ts
@@ -1326,4 +1326,149 @@ describe('Asset Coordinator Service (DI)', () => {
             coordinator.cleanupProject('non-existent-project');
         });
     });
+
+    // =========================================================================
+    // DoS hardening — bounded awareness/pending state (BUG H8)
+    // =========================================================================
+    describe('DoS hardening - awareness update bounds', () => {
+        // Mirror of MAX_ASSETS_PER_AWARENESS in asset-coordinator.ts.
+        const MAX_ASSETS_PER_AWARENESS = 5000;
+        // Mirror of MAX_ASSET_ID_LENGTH in asset-coordinator.ts.
+        const MAX_ASSET_ID_LENGTH = 256;
+
+        it('should cap the number of assets ingested from a single awareness update', async () => {
+            const socket = createMockSocket();
+            coordinator.registerClient('dos-project', 'flooder', socket);
+
+            // Announce far more distinct assets than the per-message cap allows.
+            const flood = Array.from({ length: MAX_ASSETS_PER_AWARENESS + 10000 }, (_, i) => `flood-asset-${i}`);
+            await coordinator.handleMessage('dos-project', 'flooder', {
+                type: 'awareness-update',
+                data: { availableAssets: flood },
+            });
+
+            // Tracked assets must be bounded by the per-message cap, not the
+            // size of the attacker-supplied array.
+            const stats = coordinator.getStats();
+            expect(stats.totalAssets).toBe(MAX_ASSETS_PER_AWARENESS);
+
+            coordinator.cleanupProject('dos-project');
+        });
+
+        it('should bound distinct assets per project across repeated awareness updates', async () => {
+            const socket = createMockSocket();
+            coordinator.registerClient('dos-project', 'flooder', socket);
+
+            // Send several full-cap batches with disjoint id ranges. Each batch is
+            // at the per-message cap, so distinct project assets grow, but the
+            // per-project ceiling (MAX_ASSETS_PER_PROJECT, 50000) bounds the total
+            // and a few batches stay well under it while still proving growth is
+            // accounted, not unbounded per message.
+            for (let batch = 0; batch < 3; batch++) {
+                const ids = Array.from({ length: MAX_ASSETS_PER_AWARENESS }, (_, i) => `b${batch}-asset-${i}`);
+                await coordinator.handleMessage('dos-project', 'flooder', {
+                    type: 'awareness-update',
+                    data: { availableAssets: ids },
+                });
+            }
+
+            const stats = coordinator.getStats();
+            // 3 disjoint batches of the per-message cap = 15000 distinct ids,
+            // which is under the 50000 per-project ceiling.
+            expect(stats.totalAssets).toBe(3 * MAX_ASSETS_PER_AWARENESS);
+            expect(stats.totalAssets).toBeLessThanOrEqual(50000);
+
+            coordinator.cleanupProject('dos-project');
+        });
+
+        it('should reject over-long and non-string asset ids', async () => {
+            const socket = createMockSocket();
+            coordinator.registerClient('dos-project', 'flooder', socket);
+
+            const overLongId = 'x'.repeat(MAX_ASSET_ID_LENGTH + 1);
+            await coordinator.handleMessage('dos-project', 'flooder', {
+                type: 'awareness-update',
+                data: {
+                    // Mix of invalid ids (over-long, non-string, traversal, separators)
+                    // and one valid id. Only the valid id must be tracked.
+                    availableAssets: [
+                        overLongId,
+                        42 as unknown as string,
+                        null as unknown as string,
+                        '../escape',
+                        'has/slash',
+                        'valid-asset-1',
+                    ],
+                },
+            });
+
+            const stats = coordinator.getStats();
+            expect(stats.totalAssets).toBe(1);
+
+            coordinator.cleanupProject('dos-project');
+        });
+
+        it('should accept an exactly max-length asset id', async () => {
+            const socket = createMockSocket();
+            coordinator.registerClient('dos-project', 'client-1', socket);
+
+            const maxId = 'a'.repeat(MAX_ASSET_ID_LENGTH);
+            await coordinator.handleMessage('dos-project', 'client-1', {
+                type: 'awareness-update',
+                data: { availableAssets: [maxId] },
+            });
+
+            expect(coordinator.getStats().totalAssets).toBe(1);
+
+            coordinator.cleanupProject('dos-project');
+        });
+    });
+
+    describe('DoS hardening - unregisterClient prunes orphaned assets', () => {
+        it('should remove asset-id keys with no remaining referencing client', async () => {
+            const socket1 = createMockSocket();
+            const socket2 = createMockSocket();
+            coordinator.registerClient('prune-project', 'client-1', socket1);
+            coordinator.registerClient('prune-project', 'client-2', socket2);
+
+            // client-1 exclusively holds 3 assets; client-2 shares one.
+            await coordinator.handleMessage('prune-project', 'client-1', {
+                type: 'awareness-update',
+                data: { availableAssets: ['shared-asset', 'solo-asset-1', 'solo-asset-2'] },
+            });
+            await coordinator.handleMessage('prune-project', 'client-2', {
+                type: 'awareness-update',
+                data: { availableAssets: ['shared-asset'] },
+            });
+
+            expect(coordinator.getStats().totalAssets).toBe(3);
+
+            // client-1 leaves: its two solo assets must be reclaimed immediately,
+            // while the shared asset survives because client-2 still references it.
+            coordinator.unregisterClient('prune-project', 'client-1');
+
+            const stats = coordinator.getStats();
+            expect(stats.totalAssets).toBe(1);
+
+            coordinator.cleanupProject('prune-project');
+        });
+
+        it('should drop the project entry entirely when the last client leaves', async () => {
+            const socket = createMockSocket();
+            coordinator.registerClient('prune-project', 'only-client', socket);
+
+            await coordinator.handleMessage('prune-project', 'only-client', {
+                type: 'awareness-update',
+                data: { availableAssets: ['a', 'b', 'c'] },
+            });
+            expect(coordinator.getStats().totalAssets).toBe(3);
+
+            coordinator.unregisterClient('prune-project', 'only-client');
+
+            // No lingering asset state pinned by the departed client.
+            expect(coordinator.getStats().totalAssets).toBe(0);
+
+            coordinator.cleanupProject('prune-project');
+        });
+    });
 });

--- a/src/websocket/asset-coordinator.ts
+++ b/src/websocket/asset-coordinator.ts
@@ -51,8 +51,46 @@ import {
     MAX_BATCH_BYTES,
     MAX_BATCH_FILES,
 } from '../services/upload-session-manager';
+import { isSafePathSegment } from '../utils/safe-path';
 
 const DEBUG = process.env.APP_DEBUG === '1';
+
+/**
+ * Resource limits for client-supplied awareness data (DoS hardening).
+ *
+ * `handleAwarenessUpdate` ingests an attacker-controlled `availableAssets`
+ * array and the asset coordinator keeps a per-project Set of distinct asset ids
+ * (each referencing one or more client ids) plus a `pendingRequests` map. Without
+ * caps, a single authenticated client could announce an unbounded number of
+ * distinct ids — or absurdly long ids — and drive the server heap arbitrarily
+ * high (OOM for every project on the instance). These bounds keep per-project
+ * memory bounded by a known, generous ceiling while comfortably covering any
+ * realistic collaborative project.
+ */
+
+/** Maximum asset ids processed from a single awareness-update message. */
+const MAX_ASSETS_PER_AWARENESS = 5000;
+
+/**
+ * Maximum length of an individual asset id. Asset ids are client-generated
+ * UUIDs (36 chars); 256 leaves ample headroom for prefixed/legacy ids while
+ * rejecting megabyte-sized strings crafted to inflate heap usage.
+ */
+const MAX_ASSET_ID_LENGTH = 256;
+
+/**
+ * Maximum number of distinct asset ids tracked per project across all clients.
+ * Once reached, further new ids from awareness updates are ignored (existing
+ * ids still accept new client references). A real project has far fewer assets.
+ */
+const MAX_ASSETS_PER_PROJECT = 50000;
+
+/**
+ * Maximum number of distinct pending-request keys tracked per project. Pending
+ * requests accumulate when an asset is requested before any peer has it; this
+ * bounds that queue so it cannot be used as an unbounded-growth vector.
+ */
+const MAX_PENDING_REQUESTS_PER_PROJECT = 5000;
 
 /**
  * Asset message prefix byte (0xFF)
@@ -139,6 +177,56 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
      */
     function isAssetMessage(type: string): boolean {
         return ASSET_MESSAGE_TYPES.includes(type as AssetMessageType);
+    }
+
+    /**
+     * Validate a single asset id supplied by a client.
+     * Rejects non-strings, over-long ids, and ids containing path separators,
+     * control characters or traversal tokens (asset ids are embedded in asset
+     * URLs, so the same safe-segment rules apply). Reuses the shared
+     * `isSafePathSegment` guard to keep validation logic in one place.
+     */
+    function isValidAssetId(assetId: unknown): assetId is string {
+        return isSafePathSegment(assetId, { allowDots: true, maxLength: MAX_ASSET_ID_LENGTH });
+    }
+
+    /**
+     * Count the number of distinct pending-request keys belonging to a project.
+     */
+    function countPendingForProject(projectUuid: string): number {
+        const prefix = `${projectUuid}:`;
+        let count = 0;
+        pendingRequests.forEach((_value, key) => {
+            if (key.startsWith(prefix)) {
+                count++;
+            }
+        });
+        return count;
+    }
+
+    /**
+     * Queue a pending asset request, enforcing the per-project cap. Single source
+     * of truth for the two call sites that add pending requests so the bound can
+     * never be bypassed. Appending to an existing key is always allowed; only a
+     * brand-new key counts against the cap. Returns false when the request was
+     * dropped because the project is already at its pending-request ceiling.
+     */
+    function addPendingRequest(projectUuid: string, assetId: string, request: PendingRequest): boolean {
+        const key = `${projectUuid}:${assetId}`;
+        const existing = pendingRequests.get(key);
+        if (existing) {
+            existing.push(request);
+            return true;
+        }
+        if (countPendingForProject(projectUuid) >= MAX_PENDING_REQUESTS_PER_PROJECT) {
+            console.warn(
+                `[AssetCoordinator] Project ${projectUuid} reached ${MAX_PENDING_REQUESTS_PER_PROJECT} ` +
+                    `pending requests; dropping new request from ${request.clientId}`,
+            );
+            return false;
+        }
+        pendingRequests.set(key, [request]);
+        return true;
     }
 
     /**
@@ -324,12 +412,8 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
                 );
             }
 
-            // Add to pending requests
-            const key = `${projectUuid}:${assetId}`;
-            if (!pendingRequests.has(key)) {
-                pendingRequests.set(key, []);
-            }
-            pendingRequests.get(key)!.push({
+            // Add to pending requests (bounded per project)
+            addPendingRequest(projectUuid, assetId, {
                 clientId: requestedBy,
                 timestamp: Date.now(),
                 priority: priority >= PRIORITY.HIGH ? 'high' : 'low',
@@ -407,6 +491,21 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
 
         const { availableAssets, totalAssets = availableAssets.length } = data;
 
+        // Cap the number of ids processed from a single message. Beyond the cap
+        // the extra entries are ignored (not an error): a legitimate client never
+        // announces this many assets, and an oversized array is the DoS vector.
+        const cappedAssets =
+            availableAssets.length > MAX_ASSETS_PER_AWARENESS
+                ? availableAssets.slice(0, MAX_ASSETS_PER_AWARENESS)
+                : availableAssets;
+
+        if (availableAssets.length > MAX_ASSETS_PER_AWARENESS) {
+            console.warn(
+                `[AssetCoordinator] Awareness update from ${clientId} exceeded ` +
+                    `${MAX_ASSETS_PER_AWARENESS} assets (got ${availableAssets.length}); truncating`,
+            );
+        }
+
         if (DEBUG) {
             console.log(
                 `[AssetCoordinator] Client ${clientId} has ${availableAssets.length}/${totalAssets} assets for project ${projectUuid}`,
@@ -420,16 +519,36 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
 
         const projectAssets = assetAvailability.get(projectUuid)!;
 
-        // Update availability map
-        availableAssets.forEach(assetId => {
-            if (!projectAssets.has(assetId)) {
-                projectAssets.set(assetId, new Set());
+        // Update availability map. Validate each id and bound the total number of
+        // distinct ids kept per project so a single client cannot grow server
+        // heap without limit. Adding a client reference to an already-tracked id
+        // is always allowed; only brand-new ids count against the project cap.
+        const acceptedAssets: string[] = [];
+        for (const assetId of cappedAssets) {
+            if (!isValidAssetId(assetId)) {
+                if (DEBUG) {
+                    console.warn(`[AssetCoordinator] Rejected invalid asset id from ${clientId}`);
+                }
+                continue;
             }
-            projectAssets.get(assetId)!.add(clientId);
-        });
+
+            const existing = projectAssets.get(assetId);
+            if (existing) {
+                existing.add(clientId);
+                acceptedAssets.push(assetId);
+            } else if (projectAssets.size < MAX_ASSETS_PER_PROJECT) {
+                projectAssets.set(assetId, new Set([clientId]));
+                acceptedAssets.push(assetId);
+            } else if (DEBUG) {
+                console.warn(
+                    `[AssetCoordinator] Project ${projectUuid} reached ${MAX_ASSETS_PER_PROJECT} ` +
+                        `tracked assets; ignoring new id from ${clientId}`,
+                );
+            }
+        }
 
         // Check if any pending requests can now be fulfilled
-        await checkPendingRequests(projectUuid, availableAssets);
+        await checkPendingRequests(projectUuid, acceptedAssets);
     }
 
     /**
@@ -446,6 +565,11 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         }
 
         const { assetId, priority = 'low', reason = 'render' } = data;
+
+        if (!isValidAssetId(assetId)) {
+            console.warn(`[AssetCoordinator] Rejected asset request with invalid asset id from ${clientId}`);
+            return;
+        }
 
         if (DEBUG) {
             console.log(`[AssetCoordinator] Client ${clientId} requested asset ${assetId} (${priority}, ${reason})`);
@@ -494,12 +618,8 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
             // No one has it yet
             console.warn(`[AssetCoordinator] Asset ${assetId} not found in DB and no peer has it`);
 
-            // Add to pending queue
-            const key = `${projectUuid}:${assetId}`;
-            if (!pendingRequests.has(key)) {
-                pendingRequests.set(key, []);
-            }
-            pendingRequests.get(key)!.push({
+            // Add to pending queue (bounded per project)
+            addPendingRequest(projectUuid, assetId, {
                 clientId,
                 timestamp: Date.now(),
                 priority,
@@ -971,12 +1091,24 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
             projectSocketsMap.delete(clientId);
         }
 
-        // Remove from availability tracking
+        // Remove from availability tracking and prune asset-id keys that no longer
+        // have any referencing client. Without this, a single lingering socket
+        // would pin every distinct id it ever announced until cleanupProject runs
+        // (only 30s after the LAST client leaves), letting one client keep
+        // unbounded state alive. We reclaim eagerly instead.
         const projectAssets = assetAvailability.get(projectUuid);
         if (projectAssets) {
-            projectAssets.forEach(clients => {
+            const orphanedAssetIds: string[] = [];
+            projectAssets.forEach((clients, assetId) => {
                 clients.delete(clientId);
+                if (clients.size === 0) {
+                    orphanedAssetIds.push(assetId);
+                }
             });
+            orphanedAssetIds.forEach(assetId => projectAssets.delete(assetId));
+            if (projectAssets.size === 0) {
+                assetAvailability.delete(projectUuid);
+            }
         }
 
         if (DEBUG) {

--- a/src/websocket/yjs-websocket.spec.ts
+++ b/src/websocket/yjs-websocket.spec.ts
@@ -33,6 +33,7 @@ import {
     handleWebSocketMessage,
     handleWebSocketClose,
     WsData,
+    YJS_WS_MAX_PAYLOAD_LENGTH,
     type YjsWebSocketQueries,
     type YjsWebSocketSessionManager,
     type YjsWebSocketAuth,
@@ -212,6 +213,26 @@ describe('Yjs WebSocket Service', () => {
             const routes = createWebSocketRoutes();
             const wsRoute = routes.routes.find(route => route.method === 'WS' && route.path === '/yjs/:docName');
             expect(wsRoute).toBeDefined();
+        });
+
+        it('configures an explicit conservative maxPayloadLength (DoS hardening, BUG H8)', () => {
+            const routes = createWebSocketRoutes();
+            const wsRoute = routes.routes.find(route => route.method === 'WS' && route.path === '/yjs/:docName');
+            expect(wsRoute).toBeDefined();
+
+            const wsHook = (wsRoute?.hooks as any)?.websocket;
+            expect(wsHook).toBeDefined();
+
+            // Must be set explicitly rather than relying on Bun's 16MB default.
+            expect(wsHook.maxPayloadLength).toBe(YJS_WS_MAX_PAYLOAD_LENGTH);
+        });
+
+        it('caps maxPayloadLength below Bun default but above a few-MB Yjs sync', () => {
+            // 8MB: comfortably above a multi-MB Yjs document sync, and at most
+            // half of Bun's 16MB default so a single frame cannot allocate 16MB.
+            expect(YJS_WS_MAX_PAYLOAD_LENGTH).toBe(8 * 1024 * 1024);
+            expect(YJS_WS_MAX_PAYLOAD_LENGTH).toBeLessThanOrEqual(16 * 1024 * 1024);
+            expect(YJS_WS_MAX_PAYLOAD_LENGTH).toBeGreaterThanOrEqual(4 * 1024 * 1024);
         });
     });
 

--- a/src/websocket/yjs-websocket.ts
+++ b/src/websocket/yjs-websocket.ts
@@ -161,6 +161,24 @@ const clientMetaMap = new Map<string, ClientMeta>();
 let initialized = false;
 
 /**
+ * Maximum size (in bytes) of a single WebSocket message accepted on the Yjs
+ * route. Set explicitly rather than relying on Bun's 16MB default so the per
+ * message memory an attacker can force is a known, conservative value.
+ *
+ * Two message classes flow over this socket:
+ *   1. Yjs document updates — a full Y.Doc sync of a large eXeLearning project
+ *      (many pages with embedded HTML/iDevice content) can legitimately reach a
+ *      few MB. Binary asset payloads are NOT sent here; they go through the
+ *      chunked HTTP upload endpoints, so this socket only carries document
+ *      structure/text, which stays well under the cap.
+ *   2. Asset-coordination JSON — tiny control messages (kilobytes at most).
+ *
+ * 8 MB comfortably covers the largest realistic Yjs sync while halving the
+ * 16MB default, bounding the heap a single oversized frame can allocate.
+ */
+export const YJS_WS_MAX_PAYLOAD_LENGTH = 8 * 1024 * 1024;
+
+/**
  * Generate unique client ID
  * Exported for testing
  */
@@ -456,6 +474,11 @@ export function createWebSocketRoutes() {
             // upgrade. Intentionally minimal: no counts, ports, modes or hostnames.
             .get('/yjs/info', () => ({ ok: true, service: 'yjs-websocket' }))
             .ws('/yjs/:docName', {
+                // Cap the per-message size explicitly (Bun defaults to 16MB).
+                // Bounds the heap a single oversized frame can allocate while
+                // still allowing large-but-legitimate Yjs document syncs.
+                maxPayloadLength: YJS_WS_MAX_PAYLOAD_LENGTH,
+
                 // Connection opened - validate token here since beforeHandle doesn't pass data to open
                 async open(ws) {
                     const rawData = ws.data as ElysiaWsRawData;

--- a/src/yjs/doc-lock.spec.ts
+++ b/src/yjs/doc-lock.spec.ts
@@ -100,6 +100,57 @@ describe('doc-lock', () => {
 
             release1();
         });
+
+        it('grants mutual exclusion: only one holder at a time under concurrency', async () => {
+            // Regression for the broken mutex that woke ALL waiters on release.
+            let active = 0;
+            let maxActive = 0;
+            const order: number[] = [];
+
+            const worker = async (id: number) => {
+                const release = await acquireLock('uuid-shared');
+                active += 1;
+                maxActive = Math.max(maxActive, active);
+                order.push(id);
+                // Hold briefly so overlaps would be observable.
+                await new Promise(resolve => setTimeout(resolve, 5));
+                active -= 1;
+                release();
+            };
+
+            await Promise.all([worker(1), worker(2), worker(3), worker(4), worker(5)]);
+
+            // At no point may two holders be in the critical section together.
+            expect(maxActive).toBe(1);
+            // All five ran, and the lock is fully released afterwards.
+            expect(order.length).toBe(5);
+            expect(isLocked('uuid-shared')).toBe(false);
+        });
+
+        it('hands the lock to waiters in FIFO order', async () => {
+            const release0 = await acquireLock('uuid-fifo');
+            const order: number[] = [];
+
+            const p1 = acquireLock('uuid-fifo').then(r => {
+                order.push(1);
+                return r;
+            });
+            // Ensure p1 is queued before p2.
+            await new Promise(resolve => setTimeout(resolve, 5));
+            const p2 = acquireLock('uuid-fifo').then(r => {
+                order.push(2);
+                return r;
+            });
+            await new Promise(resolve => setTimeout(resolve, 5));
+
+            release0();
+            const r1 = await p1;
+            r1();
+            const r2 = await p2;
+            r2();
+
+            expect(order).toEqual([1, 2]);
+        });
     });
 
     describe('tryAcquireLock', () => {

--- a/src/yjs/doc-lock.ts
+++ b/src/yjs/doc-lock.ts
@@ -9,7 +9,7 @@
  * - Configurable timeout to prevent deadlocks
  * - Async/await friendly API
  */
-import type { DocLockConfig, LockEntry } from './types';
+import type { DocLockConfig } from './types';
 
 // ============================================================================
 // DEFAULT CONFIGURATION
@@ -24,7 +24,56 @@ const DEFAULT_CONFIG: DocLockConfig = {
 // ============================================================================
 
 let config: DocLockConfig = { ...DEFAULT_CONFIG };
-const locks = new Map<string, LockEntry>();
+
+/**
+ * A queued waiter for a held lock. Resolved (with its own release function)
+ * when the lock is handed off to it, or rejected on timeout.
+ */
+interface LockWaiter {
+    resolve: (release: () => void) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout> | null;
+}
+
+/** Per-project mutex state: the current holder's metadata + a FIFO waiter queue. */
+interface MutexState {
+    acquiredAt: number;
+    queue: LockWaiter[];
+}
+
+const locks = new Map<string, MutexState>();
+
+/**
+ * Build a single-use release function for the current holder of `projectUuid`.
+ * On release it hands the lock to exactly one queued waiter (FIFO); if none are
+ * waiting it frees the lock. Calling the returned function more than once is a
+ * no-op, so a holder can never resurrect or double-release a lock that has
+ * already been handed off — which is what allowed multiple concurrent holders
+ * before.
+ */
+function makeRelease(projectUuid: string): () => void {
+    let released = false;
+    return () => {
+        if (released) {
+            return;
+        }
+        released = true;
+        const state = locks.get(projectUuid);
+        if (!state) {
+            return;
+        }
+        const next = state.queue.shift();
+        if (next) {
+            if (next.timer) {
+                clearTimeout(next.timer);
+            }
+            state.acquiredAt = Date.now();
+            next.resolve(makeRelease(projectUuid));
+        } else {
+            locks.delete(projectUuid);
+        }
+    };
+}
 
 // ============================================================================
 // CONFIGURATION
@@ -83,46 +132,30 @@ export class LockTimeoutError extends Error {
  * ```
  */
 export async function acquireLock(projectUuid: string): Promise<() => void> {
-    // Wait for existing lock to release (with timeout)
     const existing = locks.get(projectUuid);
-    if (existing) {
-        const timeoutPromise = new Promise<never>((_, reject) => {
-            setTimeout(() => reject(new LockTimeoutError(projectUuid, config.timeoutMs)), config.timeoutMs);
-        });
-
-        try {
-            await Promise.race([existing.promise, timeoutPromise]);
-        } catch (error) {
-            if (error instanceof LockTimeoutError) {
-                throw error;
-            }
-            // Other errors (e.g., from the existing promise) - continue to acquire
-        }
+    if (!existing) {
+        // Lock is free: take it immediately.
+        locks.set(projectUuid, { acquiredAt: Date.now(), queue: [] });
+        return makeRelease(projectUuid);
     }
 
-    // Create new lock
-    let resolveFunc!: () => void;
-    const promise = new Promise<void>(resolve => {
-        resolveFunc = resolve;
+    // Lock is held: queue and wait for our turn (FIFO) with a timeout. Exactly
+    // one queued waiter is woken per release, so there is never more than one
+    // holder at a time.
+    return new Promise<() => void>((resolve, reject) => {
+        const waiter: LockWaiter = { resolve, reject, timer: null };
+        waiter.timer = setTimeout(() => {
+            const state = locks.get(projectUuid);
+            if (state) {
+                const index = state.queue.indexOf(waiter);
+                if (index !== -1) {
+                    state.queue.splice(index, 1);
+                }
+            }
+            reject(new LockTimeoutError(projectUuid, config.timeoutMs));
+        }, config.timeoutMs);
+        existing.queue.push(waiter);
     });
-
-    const entry: LockEntry = {
-        promise,
-        resolve: resolveFunc,
-        acquiredAt: Date.now(),
-    };
-
-    locks.set(projectUuid, entry);
-
-    // Return release function
-    return () => {
-        const current = locks.get(projectUuid);
-        // Only release if this is still our lock
-        if (current?.resolve === resolveFunc) {
-            locks.delete(projectUuid);
-            resolveFunc();
-        }
-    };
 }
 
 /**
@@ -135,27 +168,8 @@ export function tryAcquireLock(projectUuid: string): (() => void) | null {
     if (locks.has(projectUuid)) {
         return null;
     }
-
-    let resolveFunc!: () => void;
-    const promise = new Promise<void>(resolve => {
-        resolveFunc = resolve;
-    });
-
-    const entry: LockEntry = {
-        promise,
-        resolve: resolveFunc,
-        acquiredAt: Date.now(),
-    };
-
-    locks.set(projectUuid, entry);
-
-    return () => {
-        const current = locks.get(projectUuid);
-        if (current?.resolve === resolveFunc) {
-            locks.delete(projectUuid);
-            resolveFunc();
-        }
-    };
+    locks.set(projectUuid, { acquiredAt: Date.now(), queue: [] });
+    return makeRelease(projectUuid);
 }
 
 /**
@@ -223,8 +237,16 @@ export function getStats(): {
  * Force release all locks (use with caution, mainly for testing)
  */
 export function releaseAll(): void {
-    for (const [, entry] of locks) {
-        entry.resolve();
+    for (const [, state] of locks) {
+        for (const waiter of state.queue) {
+            if (waiter.timer) {
+                clearTimeout(waiter.timer);
+            }
+            // Hand a no-op release to any pending waiter so awaiting callers
+            // resolve instead of hanging forever; all lock state is dropped below.
+            waiter.resolve(() => {});
+        }
+        state.queue.length = 0;
     }
     locks.clear();
 }

--- a/test/integration/routes/admin.integration.spec.ts
+++ b/test/integration/routes/admin.integration.spec.ts
@@ -37,7 +37,11 @@ import { getUserStorageUsage } from '../../../src/db/queries/assets';
 
 const TEST_JWT_SECRET = 'test_secret_for_integration_tests';
 
-// Set JWT secret environment variable so admin routes use the same secret
+// Set JWT secret environment variables so admin routes verify with the same
+// secret these tests sign with. The canonical resolver (routes/auth.getJwtSecret)
+// prefers API_JWT_SECRET, which the loaded .env sets to a different value, so we
+// must override API_JWT_SECRET — not only JWT_SECRET — here.
+process.env.API_JWT_SECRET = TEST_JWT_SECRET;
 process.env.JWT_SECRET = TEST_JWT_SECRET;
 
 // ============================================================================

--- a/views/workarea/workarea.njk
+++ b/views/workarea/workarea.njk
@@ -23,6 +23,8 @@
     <script class="exe" src="{{ '/libs/multi-dropdown.js' | asset }}" defer></script>
     <script class="exe" src="{{ '/libs/interact/interact.min.js' | asset }}" defer></script>
     <script class="exe" src="{{ '/libs/showdown/showdown.min.js' | asset }}" defer></script>
+    {# DOMPurify - sanitizes untrusted (remote collaborator) HTML before innerHTML #}
+    <script class="exe" src="{{ '/libs/dompurify/purify.min.js' | asset }}" defer></script>
     {# Asset URL Resolver - intercepts asset:// URLs and resolves them to blob URLs #}
     <script class="exe" src="{{ '/app/common/asset_url_resolver.js' | asset }}" defer></script>
     {# eXeLearning common legacy objects #}


### PR DESCRIPTION
# Security audit: fix 32 confirmed vulnerabilities (10 critical / 16 high / 5 medium / 1 low)

Fixes every issue from a multi-agent security audit that survived independent adversarial verification. Organized into themed commits grouped by root cause so the change is reviewable and bisectable. Every fix ships with colocated tests in the same change.

## Summary

- **68 files changed**, 12 commits.
- `make fix`, `make test-unit` (incl. the **per-file 90% line-coverage gate**), `make test-integration`, and `make test-e2e` all green locally.
- New `.ts` files have colocated `*.spec.ts`; new/changed `public/app` JS has colocated `*.test.js`; user-visible flows covered by existing/updated E2E specs.

## Fixes by theme

### 1. Path traversal / arbitrary file write — shared `safe-path` foundation + sinks
New `src/utils/safe-path.ts` (single source of truth: `isSafePathSegment` / `safeJoin` / `sanitizeFileExtension`) plus a fix to `file-helper.isPathSafe`, which used a naive `startsWith(base)` that treated `/data/assets-evil` as inside `/data/assets`. Applied to every sink building an on-disk path from untrusted input:
- **C1 (critical)** — `clientId` used directly as the on-disk filename across asset upload/finalize/sync/stream (`assets.ts`), batch upload (`upload-session.ts`), and API v1 (`api/v1/assets.ts`) → arbitrary file write/overwrite (webshell / DB / cross-tenant). The repo already had `isPathSafe`/`sanitizeFolderPath` but applied them to the wrong field.
- **C2 (critical)** — `odeSessionId` path param in export download (GET/POST) → arbitrary file write + directory read (`export.ts`).
- **C3 (critical)** — `themeName`/`themeId` in theme bundle/download/metadata endpoints → unauthenticated arbitrary file/dir read, incl. `.env`/DB (`themes.ts`).
- **H10 (high)** — `resumableIdentifier` chunk-directory traversal (`assets.ts`).
- **H14 (high)** — `ideviceId` metadata endpoint traversal (`idevices.ts`).

No auth added to the public theme/idevice resource endpoints (they are legitimately fetched unauthenticated by preview/embedding/static builds); the traversal validation is the fix.

### 2. Broken authorization / IDOR
- **C4 (critical)** — `POST /projects/uuid/:uuid/duplicate` had no auth/access check; any caller could clone an arbitrary private project into their account. Now requires auth + `checkProjectAccess` on the source.
- **H4 (high)** — `GET /api/games/:odeSessionId/idevices` returned full iDevice content of any project by UUID, unauthenticated. Now `withJwtAuth` + `enforceProjectAccess`. Verified the editor/preview caller is same-origin and sends the auth cookie; exported static packages never call the live endpoint.
- **M1 (medium)** — project sharing endpoints leaked owner/collaborator emails for any project (numeric variant unauthenticated + enumerable). Now require auth + access.
- **M2 (medium)** — `set_platform_new_ode` exported any project by UUID with no ownership binding. Now requires the project's `platform_id` to match the validated JWT `cmid`.

### 3. SSRF
New `src/utils/ssrf-guard.ts`: `safeFetch` allows only http(s), resolves the host and rejects private/loopback/link-local/CGNAT/unspecified addresses, and follows redirects manually re-validating each hop (DNS + fetch injectable for hermetic tests).
- **H2 (high)** — `link-validator.validateLink` fetched arbitrary URLs with `redirect: 'follow'` and no egress filter. Now routes through `safeFetch`; a blocked target is reported as broken without leaking the resolved IP.
- **H1 (high)** — `/brokenlinks` reimplemented the same unguarded fetch inline and was unauthenticated. Deleted the duplicate, calls the shared SSRF-safe service, and requires auth on all three brokenlinks endpoints.
- **M3 (medium)** — `isAllowedProviderUrl` failed **open** when `PROVIDER_URLS` was empty (the shipped default). Now fails closed; returnurls with internal-IP/non-http hosts are rejected.

### 4. Yjs persistence
- **C7 (critical)** — the document mutex woke **all** waiters on release, so several callers believed they held the lock (reproduced: 4–5 of 5 concurrent). Replaced with a real FIFO mutex; release is idempotent.
- **C6 (critical)** — REST API v1 edits were saved to `yjs_updates` with hardcoded version `'1'`, always older than the `Date.now()` snapshot version, so they were filtered out on load (silent, unrecoverable loss). Now uses a monotonic timestamp version.
- **H6 (high)** — `saveFullState` did a non-transactional delete-then-insert; a failed insert wiped state. Now wrapped in a transaction.
- **H5 (high)** — the client load endpoint read only the snapshot table; a project whose state lived in `yjs_updates` loaded empty/404. Now reconstructs snapshot + updates.
- **M6 (medium)** — `CAST(version AS INTEGER)` is rejected by MySQL (needs `SIGNED`) **and overflows 32-bit on PostgreSQL** for the millisecond-timestamp versions already in use. Now dialect-aware (`INTEGER`/`BIGINT`/`SIGNED`).

### 5. Stored / DOM XSS
- **C5 (critical)** — a remote collaborator's iDevice `htmlContent` was assigned to `innerHTML` with no sanitization (zero-click JS in every collaborator's session). New `public/app/utils/sanitizeHtml.js` (DOMPurify-backed, with a fail-safe fallback) sanitizes remote content before `innerHTML`; DOMPurify was wired into the workarea (it had only been loaded for the equation editor). `loadInitScriptIdevice` re-attaches legitimate iDevice behavior, so interactivity is preserved.
- **H12 (high)** — the File Manager list view interpolated the asset filename raw into `innerHTML` in the reference-count branch. Now escaped with the existing `escapeHtml` helper.

### 6. Resource exhaustion / DoS
- **C9 (critical)** — ELP import called `unzipSync` with no decompressed-size cap (zip bomb → OOM). Now enforces cumulative / per-entry / entry-count caps via fflate's central-directory filter, aborting before inflation, on the main, nested-ELP, and zip-contents paths.
- **H8 (high)** — client-controlled awareness `availableAssets` grew server memory unbounded. Now capped per message, ids validated, distinct entries and pending requests bounded per project, orphaned keys pruned on disconnect; explicit 8MB `maxPayloadLength` on the Yjs WS route.
- **H9 (high)** — abandoned chunked uploads never expired (disk + memory leak). Added per-chunk / total-chunk caps and a TTL sweeper (wired into server startup/shutdown).
- **M5 (medium)** — `upload-session-manager.cleanupExpired()` was defined but never scheduled. Now scheduled (with `serverPriorityQueue.cleanupStaleSlots`), wired into startup/shutdown.
- **L1 (low)** — batch upload buffered all files before checking the size cap. Now enforces the cap by declared size before buffering, with incremental-abort fallback.

### 7. Client-side data loss
- **H7 (high)** — `AssetManager._putToCache` only fell back to IndexedDB on scheme errors, so a `QuotaExceededError` was swallowed and the only in-memory blob copy was then evicted — losing it entirely. Now any cache write failure falls back to IndexedDB and only resolves after a confirmed persistent write; otherwise it re-throws so the caller keeps the blob in memory.

### 8. Auth secret / EPUB / DB / parser
- **H3 (high)** — admin/user/pages/project routes and `admin-route-helpers` each used a **divergent** local `getJwtSecret` (`JWT_SECRET || APP_SECRET || <public default>`) to **verify** tokens, while `auth.ts` **signs** with `API_JWT_SECRET || JWT_SECRET || <default>`. With the shipped `.env` (`JWT_SECRET` unset) this mismatched and broke admin auth; and if `APP_SECRET` were unset it fell back to a public in-repo constant, enabling token forgery. All now use the single canonical resolver; `APP_SECRET` stays only for platform JWTs.
- **H11 (high)** — EPUB export used blind global regexes that broke external `.html` links, mangled prose, and corrupted void elements with `>` in an attribute. Replaced with a real xmldom parse + XHTML serialize, rewriting only internal page links.
- **M4 (medium)** — `transferOwnership` ran 3 writes non-transactionally. Now atomic.
- **H13 (high)** — legacy XML import resolved each `<reference>` via a full-document scan (O(n²); ~21.8s on a crafted file). Now a Map built once per parse (sub-second).

## Re-verified, not changed
- **C8** ("Ctrl+S skips assets") — re-verified against the live code: `YjsProjectManagerMixin.save()` overrides `project.save()` and routes through `SaveManager`, which uploads pending assets before `markClean`. Not a bug; no change.
- 4 audit findings were rejected by the verifiers as false positives and are not included.

## Testing
- `make test-unit`: **7280 pass, 0 fail**; coverage gate ✓ (all 219 files ≥90% line coverage). Two files I touched near the gate were brought back over 90% with real behavior tests rather than excluded.
- `make test-integration`: green (admin integration suite's JWT env aligned with the unified resolver).
- `make test-e2e` (Playwright/chromium): green.

## Notes for reviewers
- The dual-table Yjs model (`yjs_documents` snapshot + `yjs_updates`) is preserved; this PR makes its two write paths and version schemes consistent and the load path reconstruct from both. Collapsing to a single table is a larger refactor left for follow-up.
- `set_platform_new_ode_browser` has a residual (non-exfiltrating) platform-link gap noted during M2; worth a follow-up.
